### PR TITLE
Add GitHub Actions caching

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -36,6 +36,13 @@ jobs:
       with:
         ruby-version: 2.6.3
 
+    - uses: actions/cache@v1
+      with:
+        path: vendor/bundle
+        key: ${{ runner.os }}-gems-${{ hashFiles('**/Gemfile.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-gems-
+
     - name: Setup knapsack_pro gem locally
       run: |
         mkdir ~/gems
@@ -60,6 +67,7 @@ jobs:
         KNAPSACK_PRO_REPO_PATH: ~/gems/knapsack_pro-ruby
       run: |
         gem install bundler
+        bundle config path vendor/bundle
         bundle install --jobs 4 --retry 3
         bin/rails db:setup
 

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -34,7 +34,7 @@ jobs:
     - name: Set up Ruby 2.6
       uses: actions/setup-ruby@v1
       with:
-        ruby-version: 2.6.3
+        ruby-version: 2.6.5
 
     - uses: actions/cache@v1
       with:


### PR DESCRIPTION
This feedback we got from Sasha in comments for the article https://docs.knapsackpro.com/2019/how-to-run-rspec-on-github-actions-for-ruby-on-rails-app-using-parallel-jobs

We also updated second article https://docs.knapsackpro.com/2019/github-actions-ci-config-for-ruby-on-rails-project-with-mysql-redis-elasticsearch-how-to-run-parallel-tests

# example
CI build with enabled caching is faster now https://github.com/KnapsackPro/rails-app-with-knapsack_pro/commit/36b82f4933f7d71616531471f9a658ada8aaf217/checks?check_suite_id=406716016 
Saved from 1min 30s to 15s now for `Build and create DB` step.