### PR TITLE
Create specs with duplicated helper method

### DIFF
--- a/spec/duplicated_helpers/a_spec.rb
+++ b/spec/duplicated_helpers/a_spec.rb
@@ -1,0 +1,9 @@
+def duplicated_helper
+  'a'
+end
+
+describe 'a helper' do
+  it do
+    expect(duplicated_helper).to eq 'a'
+  end
+end

--- a/spec/duplicated_helpers/b_spec.rb
+++ b/spec/duplicated_helpers/b_spec.rb
@@ -1,0 +1,9 @@
+def duplicated_helper
+  'b'
+end
+
+describe 'b helper' do
+  it do
+    expect(duplicated_helper).to eq 'b'
+  end
+end


### PR DESCRIPTION
When you run:

```
rspec spec/duplicated_helpers
```

then tests fails anyway

```
$ rspec spec/duplicated_helpers
Running via Spring preloader in process 96854
before suite

a helper
before all
around each start
before each
after each
around each stop
  should eq "a" (FAILED - 1)
after all

b helper
before all
around each start
before each
after each
around each stop
  should eq "b"
after all
after suite

Failures:

  1) a helper should eq "a"
     Failure/Error: expect(duplicated_helper).to eq 'a'

       expected: "a"
            got: "b"

       (compared using ==)
     # ./spec/duplicated_helpers/a_spec.rb:7:in `block (2 levels) in <top (required)>'
     # ./spec/spec_helper.rb:59:in `block (2 levels) in <top (required)>'
     # /Users/artur/.rvm/gems/ruby-2.6.5/gems/rspec-retry-0.6.1/lib/rspec/retry.rb:123:in `block in run'
     # /Users/artur/.rvm/gems/ruby-2.6.5/gems/rspec-retry-0.6.1/lib/rspec/retry.rb:110:in `loop'
     # /Users/artur/.rvm/gems/ruby-2.6.5/gems/rspec-retry-0.6.1/lib/rspec/retry.rb:110:in `run'
     # /Users/artur/.rvm/gems/ruby-2.6.5/gems/rspec-retry-0.6.1/lib/rspec_ext/rspec_ext.rb:12:in `run_with_retry'
     # /Users/artur/.rvm/gems/ruby-2.6.5/gems/rspec-retry-0.6.1/lib/rspec/retry.rb:37:in `block (2 levels) in setup'
     # /Users/artur/.rvm/gems/ruby-2.6.5/gems/spring-commands-rspec-1.0.4/lib/spring/commands/rspec.rb:18:in `load'
     # /Users/artur/.rvm/gems/ruby-2.6.5/gems/spring-commands-rspec-1.0.4/lib/spring/commands/rspec.rb:18:in `call'
     # -e:1:in `<main>'

Finished in 0.13185 seconds (files took 1.11 seconds to load)
2 examples, 1 failure

Failed examples:

rspec ./spec/duplicated_helpers/a_spec.rb:6 # a helper should eq "a"
```

Maybe duplicated helpers should be written differently to make it work fine in rspec run but they will fail only when using split by test examples. Not sure how to create such scenario.