### PR TITLE
Add script to test that a frequently changing list of test files in the Queue Mode can be ordered by ever recorded test files' time execution.

### DIFF
--- a/bin/knapsack_pro_all.rb
+++ b/bin/knapsack_pro_all.rb
@@ -69,6 +69,8 @@ COMMANDS = %{
 ./bin/knapsack_pro_queue_rspec_test_file_exclude_pattern 0 2
 ./bin/knapsack_pro_queue_rspec_test_file_exclude_pattern 1 2
 
+./bin/knapsack_pro_queue_rspec_frequently_changing_test_files
+
 ./bin/knapsack_pro_queue_rspec_initialized_once 0 2
 ./bin/knapsack_pro_queue_rspec_initialized_once 1 2
 

--- a/bin/knapsack_pro_queue_rspec_frequently_changing_test_files
+++ b/bin/knapsack_pro_queue_rspec_frequently_changing_test_files
@@ -8,7 +8,7 @@ export KNAPSACK_PRO_ENDPOINT=http://api.knapsackpro.test:3000
 export KNAPSACK_PRO_TEST_SUITE_TOKEN_RSPEC=a28ce51204d7c7dbd25c3352fea222cf
 export KNAPSACK_PRO_CI_NODE_TOTAL=2
 
-# generate an unique commit hash and branch
+# generate a unique commit hash and branch
 export KNAPSACK_PRO_COMMIT_HASH=$(ruby -e "require 'securerandom'; puts SecureRandom.hex")
 export KNAPSACK_PRO_BRANCH=frequently-changing-test-files-$(ruby -e "require 'securerandom'; puts SecureRandom.hex")
 
@@ -19,7 +19,7 @@ echo
 echo
 
 # Run all test files in the test suite.
-# Below commands should record time execution for all test files.
+# The commands below should record time execution for all test files.
 export KNAPSACK_PRO_CI_NODE_BUILD_ID=$(openssl rand -base64 32)
 
 KNAPSACK_PRO_CI_NODE_INDEX=0 \

--- a/bin/knapsack_pro_queue_rspec_frequently_changing_test_files
+++ b/bin/knapsack_pro_queue_rspec_frequently_changing_test_files
@@ -1,0 +1,66 @@
+#!/bin/bash
+
+# The purpose of this script is to test that a frequently changing list of test files in Queue Mode
+# can be ordered by ever recorded test files' time execution.
+
+export RAILS_ENV=test
+export KNAPSACK_PRO_ENDPOINT=http://api.knapsackpro.test:3000
+export KNAPSACK_PRO_TEST_SUITE_TOKEN_RSPEC=a28ce51204d7c7dbd25c3352fea222cf
+export KNAPSACK_PRO_CI_NODE_TOTAL=2
+
+# generate an unique commit hash and branch
+export KNAPSACK_PRO_COMMIT_HASH=$(ruby -e "require 'securerandom'; puts SecureRandom.hex")
+export KNAPSACK_PRO_BRANCH=frequently-changing-test-files-$(ruby -e "require 'securerandom'; puts SecureRandom.hex")
+
+echo
+echo
+echo "=== Step 1 ====================================================="
+echo
+echo
+
+# Run all test files in the test suite.
+# Below commands should record time execution for all test files.
+export KNAPSACK_PRO_CI_NODE_BUILD_ID=$(openssl rand -base64 32)
+
+KNAPSACK_PRO_CI_NODE_INDEX=0 \
+  bundle exec rake "knapsack_pro:queue:rspec[--format documentation]"
+
+KNAPSACK_PRO_CI_NODE_INDEX=1 \
+  bundle exec rake "knapsack_pro:queue:rspec[--format documentation]"
+
+
+echo
+echo
+echo "=== Step 2 ====================================================="
+echo
+echo
+
+# Run only controllers' specs.
+# Expect Queue API to return test files ordered by time execution recorded in the previous CI build run.
+export KNAPSACK_PRO_CI_NODE_BUILD_ID=$(openssl rand -base64 32)
+export KNAPSACK_PRO_TEST_FILE_PATTERN="spec/controllers/**{,/*/**}/*_spec.rb"
+
+KNAPSACK_PRO_CI_NODE_INDEX=0 \
+  bundle exec rake "knapsack_pro:queue:rspec[--format documentation]"
+
+KNAPSACK_PRO_CI_NODE_INDEX=1 \
+  bundle exec rake "knapsack_pro:queue:rspec[--format documentation]"
+
+echo
+echo
+echo "=== Step 3 ====================================================="
+echo
+echo
+
+# Run services specs only.
+# In the previous CI build, we recorded time execution for controllers' specs only.
+# Despite that, we expect the Queue API will return services specs ordered based on ever recorded
+# services specs' time execution.
+export KNAPSACK_PRO_CI_NODE_BUILD_ID=$(openssl rand -base64 32)
+export KNAPSACK_PRO_TEST_FILE_PATTERN="spec/services/**{,/*/**}/*_spec.rb"
+
+KNAPSACK_PRO_CI_NODE_INDEX=0 \
+  bundle exec rake "knapsack_pro:queue:rspec[--format documentation]"
+
+KNAPSACK_PRO_CI_NODE_INDEX=1 \
+  bundle exec rake "knapsack_pro:queue:rspec[--format documentation]"


### PR DESCRIPTION
Script to manually tests if our API works as expected after we introduce a new feature on Queue API side to order tests based on ever recorded test files time execution.

# related
https://github.com/KnapsackPro/knapsack_pro-ruby/issues/146#issuecomment-853400808