### PR TITLE
Update test example to test `:focus` tag behaviour

### DIFF
--- a/spec/controllers/articles_controller_spec.rb
+++ b/spec/controllers/articles_controller_spec.rb
@@ -1,4 +1,6 @@
-describe ArticlesController do
+# Change :xfocus to :focus to test behaviour when
+# config.filter_run_when_matching :focus is set in spec/spec_helper.rb
+describe ArticlesController, :xfocus do
   describe '#index' do
     let(:articles) do
       [

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -170,8 +170,16 @@ RSpec.configure do |config|
   end
 
   # Uncomment for testing purposes
+  # https://knapsackpro.com/faq/question/why-is-rspec-skipping-some-of-the-tests#if-you-have-too-many-test-files-with-focus-tag-and-you-dont-want-to-remove-the-tag-manually
   # https://knapsackpro.com/faq/question/how-to-split-slow-rspec-test-files-by-test-examples-by-individual-it#warning-dont-use-deprecated-rspec-run_all_when_everything_filtered-option
   #config.filter_run_when_matching :focus
+  #config.filter_run :focus
+  #config.run_all_when_everything_filtered = true
+  #config.filter_run_including :focus => true
+  #config.filter_run_including :focus2 => true
+  # unless ENV['CI']
+  #   config.filter_run_when_matching :focus
+  # end
 
 # The settings below are suggested to provide a good initial experience
 # with RSpec, but feel free to customize to your heart's content.

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -170,7 +170,7 @@ RSpec.configure do |config|
   end
 
   # Uncomment for testing purposes
-  # https://knapsackpro.com/faq/question/why-is-rspec-skipping-some-of-the-tests#if-you-have-too-many-test-files-with-focus-tag-and-you-dont-want-to-remove-the-tag-manually
+  # https://knapsackpro.com/faq/question/rspec-is-not-running-some-tests
   # https://knapsackpro.com/faq/question/how-to-split-slow-rspec-test-files-by-test-examples-by-individual-it#warning-dont-use-deprecated-rspec-run_all_when_everything_filtered-option
   #config.filter_run_when_matching :focus
   #config.filter_run :focus


### PR DESCRIPTION
Update example `filter_run_when_matching` so that it is always run with `run_all_when_everything_filtered` (but it could still lead to skipping tests with a set of tests fetched from the Queue has at least 1 test case with focus tag then only focused test is executed and all other test files among the set are skipped).

Add example to test `:focus` tag tests that should trigger exception from knapsack_pro gem when `config.filter_run_when_matching :focus` is set in `spec_helper.rb`.

# related fix in knapsack_pro gem

* https://github.com/KnapsackPro/knapsack_pro-ruby/pull/167