### PR TITLE
Add bin examples for the improved RSpec Queue Mode runner log output that has added seed

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -96,6 +96,10 @@ jobs:
       # Test --profile formatter to show only once the profile summary.
       - run: KNAPSACK_PRO_FIXED_QUEUE_SPLIT=true KNAPSACK_PRO_TEST_SUITE_TOKEN_RSPEC=$KNAPSACK_PRO_QUEUE_TEST_SUITE_TOKEN_RSPEC bundle exec rake "knapsack_pro:queue:rspec[--profile]"
 
+      # Queue Mode - retry the CI build with the same test suite split as the last knapsack_pro command execution for this CI build
+      # add the RSpec order option to ensure we print a seed in the log output
+      - run: KNAPSACK_PRO_FIXED_QUEUE_SPLIT=true KNAPSACK_PRO_TEST_SUITE_TOKEN_RSPEC=$KNAPSACK_PRO_QUEUE_TEST_SUITE_TOKEN_RSPEC bundle exec rake "knapsack_pro:queue:rspec[--order random]"
+
       # Queue mode with junit formatter
       # Retry CI with the same test suite split as last dynamic queue run
       # The rspec.xml will have tests from all intermediate requests to API.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../knapsack_pro-ruby
   specs:
-    knapsack_pro (3.4.0)
+    knapsack_pro (3.4.1)
       rake
 
 GEM

--- a/bin/knapsack_pro_all.rb
+++ b/bin/knapsack_pro_all.rb
@@ -80,6 +80,18 @@ COMMANDS = %{
 ./bin/knapsack_pro_queue_rspec_only_failures 0 2
 ./bin/knapsack_pro_queue_rspec_only_failures 1 2
 
+./bin/knapsack_pro_queue_rspec_order_defined 0 2
+./bin/knapsack_pro_queue_rspec_order_defined 1 2
+
+./bin/knapsack_pro_queue_rspec_order_rand 0 2
+./bin/knapsack_pro_queue_rspec_order_rand 1 2
+
+./bin/knapsack_pro_queue_rspec_order_rand_with_custom_seed 0 2
+./bin/knapsack_pro_queue_rspec_order_rand_with_custom_seed 1 2
+
+./bin/knapsack_pro_queue_rspec_order_random 0 2
+./bin/knapsack_pro_queue_rspec_order_random 1 2
+
 ./bin/knapsack_pro_fixed_queue_rspec_queue_consumed_at_least_once_with_ci_build_id
 
 ./bin/knapsack_pro_fixed_queue_rspec_queue_consumed_at_least_once_without_ci_build_id

--- a/bin/knapsack_pro_all.rb
+++ b/bin/knapsack_pro_all.rb
@@ -92,6 +92,9 @@ COMMANDS = %{
 ./bin/knapsack_pro_queue_rspec_order_random 0 2
 ./bin/knapsack_pro_queue_rspec_order_random 1 2
 
+./bin/knapsack_pro_queue_rspec_order_random_defined_in_config 0 2
+./bin/knapsack_pro_queue_rspec_order_random_defined_in_config 1 2
+
 ./bin/knapsack_pro_fixed_queue_rspec_queue_consumed_at_least_once_with_ci_build_id
 
 ./bin/knapsack_pro_fixed_queue_rspec_queue_consumed_at_least_once_without_ci_build_id

--- a/bin/knapsack_pro_queue_rspec_order_defined
+++ b/bin/knapsack_pro_queue_rspec_order_defined
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+RAILS_ENV=test \
+  KNAPSACK_PRO_ENDPOINT=http://api.knapsackpro.test:3000 \
+  KNAPSACK_PRO_TEST_SUITE_TOKEN_RSPEC=a28ce51204d7c7dbd25c3352fea222cf \
+  KNAPSACK_PRO_REPOSITORY_ADAPTER=git \
+  KNAPSACK_PRO_PROJECT_DIR=. \
+  KNAPSACK_PRO_CI_NODE_TOTAL=${2:-2} \
+  KNAPSACK_PRO_CI_NODE_INDEX=${1:-0} \
+  bundle exec rake "knapsack_pro:queue:rspec[--order defined]"

--- a/bin/knapsack_pro_queue_rspec_order_rand
+++ b/bin/knapsack_pro_queue_rspec_order_rand
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+RAILS_ENV=test \
+  KNAPSACK_PRO_ENDPOINT=http://api.knapsackpro.test:3000 \
+  KNAPSACK_PRO_TEST_SUITE_TOKEN_RSPEC=a28ce51204d7c7dbd25c3352fea222cf \
+  KNAPSACK_PRO_REPOSITORY_ADAPTER=git \
+  KNAPSACK_PRO_PROJECT_DIR=. \
+  KNAPSACK_PRO_CI_NODE_TOTAL=${2:-2} \
+  KNAPSACK_PRO_CI_NODE_INDEX=${1:-0} \
+  bundle exec rake "knapsack_pro:queue:rspec[--order rand]"

--- a/bin/knapsack_pro_queue_rspec_order_rand_with_custom_seed
+++ b/bin/knapsack_pro_queue_rspec_order_rand_with_custom_seed
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+RAILS_ENV=test \
+  KNAPSACK_PRO_ENDPOINT=http://api.knapsackpro.test:3000 \
+  KNAPSACK_PRO_TEST_SUITE_TOKEN_RSPEC=a28ce51204d7c7dbd25c3352fea222cf \
+  KNAPSACK_PRO_REPOSITORY_ADAPTER=git \
+  KNAPSACK_PRO_PROJECT_DIR=. \
+  KNAPSACK_PRO_CI_NODE_TOTAL=${2:-2} \
+  KNAPSACK_PRO_CI_NODE_INDEX=${1:-0} \
+  bundle exec rake "knapsack_pro:queue:rspec[--order rand:123]"

--- a/bin/knapsack_pro_queue_rspec_order_random
+++ b/bin/knapsack_pro_queue_rspec_order_random
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+RAILS_ENV=test \
+  KNAPSACK_PRO_ENDPOINT=http://api.knapsackpro.test:3000 \
+  KNAPSACK_PRO_TEST_SUITE_TOKEN_RSPEC=a28ce51204d7c7dbd25c3352fea222cf \
+  KNAPSACK_PRO_REPOSITORY_ADAPTER=git \
+  KNAPSACK_PRO_PROJECT_DIR=. \
+  KNAPSACK_PRO_CI_NODE_TOTAL=${2:-2} \
+  KNAPSACK_PRO_CI_NODE_INDEX=${1:-0} \
+  bundle exec rake "knapsack_pro:queue:rspec[--order random]"

--- a/bin/knapsack_pro_queue_rspec_order_random_defined_in_config
+++ b/bin/knapsack_pro_queue_rspec_order_random_defined_in_config
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+RAILS_ENV=test \
+  KNAPSACK_PRO_ENDPOINT=http://api.knapsackpro.test:3000 \
+  KNAPSACK_PRO_TEST_SUITE_TOKEN_RSPEC=a28ce51204d7c7dbd25c3352fea222cf \
+  KNAPSACK_PRO_REPOSITORY_ADAPTER=git \
+  KNAPSACK_PRO_PROJECT_DIR=. \
+  KNAPSACK_PRO_CI_NODE_TOTAL=${2:-2} \
+  KNAPSACK_PRO_CI_NODE_INDEX=${1:-0} \
+  RSPEC_ORDER_RANDOM_DEFINED_IN_CONFIG=true \
+  bundle exec rake knapsack_pro:queue:rspec

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -47,6 +47,10 @@ RSpec.configure do |config|
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures
   config.fixture_path = "#{::Rails.root}/spec/fixtures"
 
+  if ENV['RSPEC_ORDER_RANDOM_DEFINED_IN_CONFIG']
+    config.order = 'random'
+  end
+
   # If you're not using ActiveRecord, or you'd prefer not to run each of your
   # examples within a transaction, remove the following line or assign false
   # instead of true.


### PR DESCRIPTION
# testing scenarios

* pass each possible option to the knapsack_pro command
  * --order defined
  * --order rand
  * --order random
  * --order rand:123
* check case when `.rspec` file has the `--order` option defined. I tested this manually.
* what if someone defined the order option in the RSpec code in the rails_helper.rb or spec_helper.rb file. It works. I added bin example for that.
* run the `bin/knapsack_pro_all` script from the project rails-app-with-knapsack_pro. All tests pass with success!


# Related PR

Improve the RSpec Queue Mode runner log output (add seed)
https://github.com/KnapsackPro/knapsack_pro-ruby/pull/178