### PR TITLE
Update CodeFresh config (add missing registry)

### DIFF
--- a/.codefresh/codefresh.yml
+++ b/.codefresh/codefresh.yml
@@ -17,10 +17,11 @@ steps:
     title: Building Test Docker image
     type: build
     arguments:
-      image_name: '${{CF_ACCOUNT}}/${{CF_REPO_NAME}}-test'
+      image_name: "knapsackpro/${{CF_REPO_NAME}}-codefresh"
       tag: '${{CF_BRANCH_TAG_NORMALIZED}}-${{CF_SHORT_REVISION}}'
       dockerfile: Test.Dockerfile
     stage: "build"
+    registry: knapsackpro
 
   run_tests:
     stage: "tests"
@@ -46,7 +47,7 @@ steps:
             - 5432
     matrix:
       environment:
-        # please ensure you have here listed N-1 indexes
+        # ensure you listed N-1 indexes here
         # where N is KNAPSACK_PRO_CI_NODE_TOTAL
         - KNAPSACK_PRO_CI_NODE_INDEX=0
         - KNAPSACK_PRO_CI_NODE_INDEX=1

--- a/Test.Dockerfile
+++ b/Test.Dockerfile
@@ -14,9 +14,6 @@ RUN apk add --update \
   git \
   && rm -rf /var/cache/apk/*
 
-# Install AWS CLI
-#RUN pip3 install awscli
-
 # Use libxml2, libxslt a packages from alpine for building nokogiri
 RUN bundle config build.nokogiri --use-system-libraries
 

--- a/Test.Dockerfile
+++ b/Test.Dockerfile
@@ -15,7 +15,7 @@ RUN apk add --update \
   && rm -rf /var/cache/apk/*
 
 # Install AWS CLI
-RUN pip3 install awscli
+#RUN pip3 install awscli
 
 # Use libxml2, libxslt a packages from alpine for building nokogiri
 RUN bundle config build.nokogiri --use-system-libraries


### PR DESCRIPTION
# Codefresh 

Codefresh CI requires to migrate to a new container registry.
https://g.codefresh.io/account-admin/account-conf/cfcr-deprecation

Codefresh docs for fields in YML config
https://codefresh.io/docs/docs/pipelines/steps/push/

# Docker Hub

I configured Docker Hub for us.
https://codefresh.io/docs/docs/integrations/docker-registries/docker-hub/

Here are docker images published for each CI build: 
https://hub.docker.com/r/knapsackpro/rails-app-with-knapsack_pro-codefresh/tags


