### PR TITLE
Add bin script example to test the `SPEC_OPTS` env var with the RSpec split by test examples feature

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../knapsack_pro-ruby
   specs:
-    knapsack_pro (5.1.1)
+    knapsack_pro (5.1.2)
       rake
 
 GEM

--- a/bin/knapsack_pro_all.rb
+++ b/bin/knapsack_pro_all.rb
@@ -21,6 +21,7 @@ COMMANDS = {
   './bin/knapsack_pro_queue_rspec_user_seat' => ['0 2 BUILD_ID', '1 2 BUILD_ID'],
   './bin/knapsack_pro_queue_rspec_record_first_run' => ['0 2', '1 2'],
   './bin/knapsack_pro_queue_rspec_split_by_test_examples' => ['0 2 BUILD_ID', '1 2 BUILD_ID'],
+  './bin/knapsack_pro_queue_rspec_split_by_test_examples_spec_opts' => ['0 2 BUILD_ID', '1 2 BUILD_ID'],
   './bin/knapsack_pro_queue_rspec_split_by_test_examples_test_example_detector_prefix' => ['0 2 BUILD_ID', '1 2 BUILD_ID'],
   './bin/knapsack_pro_queue_rspec_tags' => ['0 2 BUILD_ID', '1 2 BUILD_ID'],
   './bin/knapsack_pro_queue_rspec_default_formatter' => ['0 2 BUILD_ID', '1 2 BUILD_ID'],

--- a/bin/knapsack_pro_all.rb
+++ b/bin/knapsack_pro_all.rb
@@ -74,15 +74,18 @@ COMMANDS = {
 }
 
 failed_commands = []
+commands_count = COMMANDS.values.flatten.size
 
-COMMANDS.each do |command, args|
+COMMANDS.each_with_index do |(command, args), command_index|
   uuid = SecureRandom.uuid
 
   args
     .map { _1.sub('BUILD_ID', uuid) }
     .each do |arg|
       cmd = [command, arg].join(' ')
-      puts "EXECUTING: #{cmd}"
+      puts "="*50
+      puts "EXECUTING (#{command_index+1} of #{commands_count}): #{cmd}"
+      puts
       system(cmd)
 
       (failed_commands << command) if $?.exitstatus != 0

--- a/bin/knapsack_pro_queue_rspec_split_by_test_examples_spec_opts
+++ b/bin/knapsack_pro_queue_rspec_split_by_test_examples_spec_opts
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+#export KNAPSACK_PRO_LOG_LEVEL=warn
+
+# uncomment to run all tests split by examples
+#export KNAPSACK_PRO_SLOW_TEST_FILE_PATTERN="spec/**{,/*/**}/*_spec.rb"
+export KNAPSACK_PRO_SLOW_TEST_FILE_PATTERN="spec/controllers/**{,/*/**}/*_spec.rb"
+
+export KNAPSACK_PRO_TEST_FILE_LIST=spec/controllers/articles_controller_spec.rb,spec/controllers/welcome_controller_spec.rb
+
+#export KNAPSACK_PRO_RSPEC_TEST_EXAMPLE_DETECTOR_PREFIX="SPEC_OPTS=''"
+
+#export EXTRA_TEST_FILES_DELAY=10 # seconds
+
+export SPEC_OPTS="--format documentation"
+
+RAILS_ENV=test \
+  KNAPSACK_PRO_ENDPOINT=http://api.knapsackpro.test:3000 \
+  KNAPSACK_PRO_TEST_SUITE_TOKEN_RSPEC=a28ce51204d7c7dbd25c3352fea222cf \
+  KNAPSACK_PRO_REPOSITORY_ADAPTER=git \
+  KNAPSACK_PRO_PROJECT_DIR=. \
+  KNAPSACK_PRO_CI_NODE_TOTAL=${2:-2} \
+  KNAPSACK_PRO_CI_NODE_INDEX=${1:-0} \
+  KNAPSACK_PRO_RSPEC_SPLIT_BY_TEST_EXAMPLES=true \
+  bundle exec rake "knapsack_pro:queue:rspec"

--- a/bin/knapsack_pro_queue_rspec_split_by_test_examples_spec_opts
+++ b/bin/knapsack_pro_queue_rspec_split_by_test_examples_spec_opts
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+CI_BUILD_ID=$(openssl rand -base64 32)
+
 #export KNAPSACK_PRO_LOG_LEVEL=warn
 
 # uncomment to run all tests split by examples
@@ -12,7 +14,8 @@ export KNAPSACK_PRO_TEST_FILE_LIST=spec/controllers/articles_controller_spec.rb,
 
 #export EXTRA_TEST_FILES_DELAY=10 # seconds
 
-export SPEC_OPTS="--format documentation"
+# overrides the options passed to the Knapsack Pro command
+export SPEC_OPTS="--format json"
 
 RAILS_ENV=test \
   KNAPSACK_PRO_ENDPOINT=http://api.knapsackpro.test:3000 \
@@ -21,5 +24,6 @@ RAILS_ENV=test \
   KNAPSACK_PRO_PROJECT_DIR=. \
   KNAPSACK_PRO_CI_NODE_TOTAL=${2:-2} \
   KNAPSACK_PRO_CI_NODE_INDEX=${1:-0} \
+  KNAPSACK_PRO_CI_NODE_BUILD_ID=${3:-$CI_BUILD_ID} \
   KNAPSACK_PRO_RSPEC_SPLIT_BY_TEST_EXAMPLES=true \
-  bundle exec rake "knapsack_pro:queue:rspec"
+  bundle exec rake "knapsack_pro:queue:rspec[--format documentation]"

--- a/bin/knapsack_pro_queue_rspec_split_by_test_examples_spec_opts
+++ b/bin/knapsack_pro_queue_rspec_split_by_test_examples_spec_opts
@@ -10,10 +10,6 @@ export KNAPSACK_PRO_SLOW_TEST_FILE_PATTERN="spec/controllers/**{,/*/**}/*_spec.r
 
 export KNAPSACK_PRO_TEST_FILE_LIST=spec/controllers/articles_controller_spec.rb,spec/controllers/welcome_controller_spec.rb
 
-#export KNAPSACK_PRO_RSPEC_TEST_EXAMPLE_DETECTOR_PREFIX="SPEC_OPTS=''"
-
-#export EXTRA_TEST_FILES_DELAY=10 # seconds
-
 # overrides the options passed to the Knapsack Pro command
 export SPEC_OPTS="--format json"
 


### PR DESCRIPTION
* Add bin script example to test the `SPEC_OPTS` env var with the RSpec split by test examples feature.
  * Create `bin/knapsack_pro_queue_rspec_split_by_test_examples_spec_opts`

# TODO

* [x] consider adding this bin script to the `bin/knapsack_pro_all.rb` file.

# related

* https://github.com/KnapsackPro/knapsack_pro-ruby/pull/191