### PR TITLE
Testing if all test cases are executed when using the RSpec split by test examples

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -106,3 +106,4 @@ group :test do
 end
 
 gem "turnip", "~> 4.4"
+gem 'juniter'

--- a/Gemfile
+++ b/Gemfile
@@ -62,8 +62,9 @@ group :development, :test do
   if ENV['USE_KNAPSACK_PRO_FROM_RUBYGEMS']
     gem 'knapsack_pro'
   else
-    gem 'knapsack_pro', path: ENV['KNAPSACK_PRO_REPO_PATH'] || '../knapsack_pro-ruby'
+    #gem 'knapsack_pro', path: ENV['KNAPSACK_PRO_REPO_PATH'] || '../knapsack_pro-ruby'
     #gem 'knapsack_pro', github: 'KnapsackPro/knapsack_pro-ruby', branch: 'rspec-queue-mode-record-timing-fix'
+    gem 'knapsack_pro', github: 'tubaxenor/knapsack_pro-ruby', branch: 'runner-refactor'
   end
 
   gem 'test-unit-rails'

--- a/Gemfile
+++ b/Gemfile
@@ -62,9 +62,8 @@ group :development, :test do
   if ENV['USE_KNAPSACK_PRO_FROM_RUBYGEMS']
     gem 'knapsack_pro'
   else
-    #gem 'knapsack_pro', path: ENV['KNAPSACK_PRO_REPO_PATH'] || '../knapsack_pro-ruby'
+    gem 'knapsack_pro', path: ENV['KNAPSACK_PRO_REPO_PATH'] || '../knapsack_pro-ruby'
     #gem 'knapsack_pro', github: 'KnapsackPro/knapsack_pro-ruby', branch: 'rspec-queue-mode-record-timing-fix'
-    gem 'knapsack_pro', github: 'tubaxenor/knapsack_pro-ruby', branch: 'runner-refactor'
   end
 
   gem 'test-unit-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,5 @@
-GIT
-  remote: https://github.com/tubaxenor/knapsack_pro-ruby.git
-  revision: 575ef6f641d61607a17c05332591308b6d899d72
-  branch: runner-refactor
+PATH
+  remote: ../knapsack_pro-ruby
   specs:
     knapsack_pro (6.0.3)
       rake

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -172,6 +172,8 @@ GEM
       railties (>= 4.2.0)
       thor (>= 0.14, < 2.0)
     json (2.6.3)
+    juniter (0.1.2)
+      ox
     launchy (2.5.2)
       addressable (~> 2.8)
     listen (3.8.0)
@@ -208,6 +210,7 @@ GEM
     nokogiri (1.14.2)
       mini_portile2 (~> 2.8.0)
       racc (~> 1.4)
+    ox (2.14.17)
     parallel (1.22.1)
     parallel_tests (4.2.0)
       parallel
@@ -396,6 +399,7 @@ DEPENDENCIES
   database_cleaner
   jbuilder (~> 2.0)
   jquery-rails
+  juniter
   knapsack_pro!
   listen
   net-imap

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,5 +1,7 @@
-PATH
-  remote: ../knapsack_pro-ruby
+GIT
+  remote: https://github.com/tubaxenor/knapsack_pro-ruby.git
+  revision: 575ef6f641d61607a17c05332591308b6d899d72
+  branch: runner-refactor
   specs:
     knapsack_pro (6.0.3)
       rake

--- a/bin/collect_junit_xml_reports.rb
+++ b/bin/collect_junit_xml_reports.rb
@@ -1,12 +1,10 @@
 # How to use it:
-# $ ruby bin/collect_junit_xml_reports.rb
+# ruby bin/collect_junit_xml_reports.rb > tmp/junit_test_cases_summary.txt && cat tmp/junit_test_cases_summary.txt
+# ruby bin/collect_junit_xml_reports.rb > tmp/junit_test_cases_summary2.txt && cat tmp/junit_test_cases_summary2.txt
 #
-# $ ruby bin/collect_junit_xml_reports.rb > tmp/junit_test_cases_summary.txt && cat tmp/junit_test_cases_summary.txt
-# $ ruby bin/collect_junit_xml_reports.rb > tmp/junit_test_cases_summary2.txt && cat tmp/junit_test_cases_summary2.txt
-#
-# Find differences:
+# Show a diff:
 # git diff --no-index tmp/junit_test_cases_summary.txt tmp/junit_test_cases_summary2.txt
-# OR
+# or
 # diff tmp/junit_test_cases_summary.txt tmp/junit_test_cases_summary2.txt
 
 require 'juniter'

--- a/bin/collect_junit_xml_reports.rb
+++ b/bin/collect_junit_xml_reports.rb
@@ -1,0 +1,27 @@
+# How to use it:
+# $ ruby bin/collect_junit_xml_reports.rb
+
+require 'juniter'
+
+report_directory = 'tmp/test-reports/rspec/queue_mode'
+xml_files = Dir.glob("#{report_directory}/rspec_final_results_*.xml")
+tests = []
+
+xml_files.each do |file_name|
+  xml = Juniter.from_file(file_name)
+
+  xml.test_suites.test_suites.each do |test_suite|
+    test_suite.test_cases.each do |test_case|
+      class_name = test_case.class_name
+      name = test_case.name
+      test = "#{class_name}, #{name}"
+      tests << test
+    end
+  end
+end
+
+tests.sort!
+
+puts tests
+puts
+puts "Test cases: #{tests.size}"

--- a/bin/collect_junit_xml_reports.rb
+++ b/bin/collect_junit_xml_reports.rb
@@ -1,5 +1,13 @@
 # How to use it:
 # $ ruby bin/collect_junit_xml_reports.rb
+#
+# $ ruby bin/collect_junit_xml_reports.rb > tmp/junit_test_cases_summary.txt && cat tmp/junit_test_cases_summary.txt
+# $ ruby bin/collect_junit_xml_reports.rb > tmp/junit_test_cases_summary2.txt && cat tmp/junit_test_cases_summary2.txt
+#
+# Find differences:
+# git diff --no-index tmp/junit_test_cases_summary.txt tmp/junit_test_cases_summary2.txt
+# OR
+# diff tmp/junit_test_cases_summary.txt tmp/junit_test_cases_summary2.txt
 
 require 'juniter'
 

--- a/bin/knapsack_pro_all.rb
+++ b/bin/knapsack_pro_all.rb
@@ -20,6 +20,7 @@ COMMANDS = {
   './bin/knapsack_pro_queue_rspec' => ['0 2 BUILD_ID', '1 2 BUILD_ID'],
   './bin/knapsack_pro_queue_rspec_user_seat' => ['0 2 BUILD_ID', '1 2 BUILD_ID'],
   './bin/knapsack_pro_queue_rspec_record_first_run' => ['0 2', '1 2'],
+  './bin/knapsack_pro_queue_rspec_record_first_run_junit' => ['0 2 COMMIT_HASH BUILD_ID', '1 2 COMMIT_HASH BUILD_ID'],
   './bin/knapsack_pro_queue_rspec_split_by_test_examples' => ['0 2 BUILD_ID', '1 2 BUILD_ID'],
   './bin/knapsack_pro_queue_rspec_split_by_test_examples_spec_opts' => ['0 2 BUILD_ID', '1 2 BUILD_ID'],
   './bin/knapsack_pro_queue_rspec_split_by_test_examples_test_example_detector_prefix' => ['0 2 BUILD_ID', '1 2 BUILD_ID'],
@@ -81,9 +82,11 @@ commands_count = COMMANDS.keys.size
 
 COMMANDS.each_with_index do |(command, args), command_index|
   uuid = SecureRandom.uuid
+  commit_hash = SecureRandom.hex
 
   args
     .map { _1.sub('BUILD_ID', uuid) }
+    .map { _1.sub('COMMIT_HASH', commit_hash) }
     .each do |arg|
       cmd = [command, arg].join(' ')
       puts "="*50

--- a/bin/knapsack_pro_queue_rspec_record_first_run_junit
+++ b/bin/knapsack_pro_queue_rspec_record_first_run_junit
@@ -1,16 +1,11 @@
 #!/bin/bash
-
-# This file uses separate KNAPSACK_PRO_TEST_SUITE_TOKEN_RSPEC
-# to don't pollute master and other default branches
-# so thanks to that we can test a new queue generated on API side
-# for test files with not recorded time execution
 #
-# This file can be used to test how to optimise the first run of Queue Mode and collect junit reports
+# Run a new CI build in Queue Mode and collect JUnit reports.
 #
-# To run tests on the same commit for all nodes do:
-# CI node 0 for commit-v1
+# Do the following to run tests on the same commit for all nodes:
+# CI node 0
 # bin/knapsack_pro_queue_rspec_record_first_run_junit 0 2 commit-v1 ci-build-1
-# CI node 1 for commit-v2
+# CI node 1
 # bin/knapsack_pro_queue_rspec_record_first_run_junit 1 2 commit-v1 ci-build-1
 
 mkdir -p tmp/test-reports/rspec/queue_mode/
@@ -21,18 +16,10 @@ RANDOM_COMMIT_HASH=$(ruby -e "require 'securerandom'; puts SecureRandom.hex")
 COMMIT_HASH=${4:-$RANDOM_COMMIT_HASH}
 BRANCH_NAME=fake-junit-branch
 
-# you can set a const fake data if you need to test running tests on 2 CI nodes for the same commit/branch
-#COMMIT_HASH=57dccc53cb2ee921692ad1d3df971674
-
-# must be exported to read value in below knapsack_pro command
-export KNAPSACK_PRO_CI_NODE_INDEX=${1:-0}
-
-#export KNAPSACK_PRO_FIXED_QUEUE_SPLIT=true
-
 export EXTRA_TEST_FILES_DELAY=10 # seconds
-
-# uncomment to run all tests split by examples
+export KNAPSACK_PRO_CI_NODE_INDEX=${1:-0}
 export KNAPSACK_PRO_SLOW_TEST_FILE_PATTERN="spec/**{,/*/**}/*_spec.rb"
+#export KNAPSACK_PRO_FIXED_QUEUE_SPLIT=true
 
 KNAPSACK_PRO_ENDPOINT=http://api.knapsackpro.test:3000 \
   KNAPSACK_PRO_TEST_SUITE_TOKEN_RSPEC=fec3c641a3c4d2e720fe1b6d9dd780bc \

--- a/bin/knapsack_pro_queue_rspec_record_first_run_junit
+++ b/bin/knapsack_pro_queue_rspec_record_first_run_junit
@@ -1,0 +1,41 @@
+#!/bin/bash
+
+# This file uses separate KNAPSACK_PRO_TEST_SUITE_TOKEN_RSPEC
+# to don't pollute master and other default branches
+# so thanks to that we can test a new queue generated on API side
+# for test files with not recorded time execution
+#
+# This file can be used to test how to optimise the first run of Queue Mode and collect junit reports
+#
+# To run tests on the same commit for all nodes do:
+# CI node 0 for commit-v1
+# bin/knapsack_pro_queue_rspec_record_first_run_junit 0 2 commit-v1 ci-build-1
+# CI node 1 for commit-v2
+# bin/knapsack_pro_queue_rspec_record_first_run_junit 1 2 commit-v1 ci-build-1
+
+mkdir -p tmp/test-reports/rspec/first_run_junit_queue_mode/
+
+RANDOM_CI_BUILD_ID=$(openssl rand -base64 32)
+CI_BUILD_ID=${3:-$RANDOM_CI_BUILD_ID}
+RANDOM_COMMIT_HASH=$(ruby -e "require 'securerandom'; puts SecureRandom.hex")
+COMMIT_HASH=${4:-$RANDOM_COMMIT_HASH}
+BRANCH_NAME=fake-junit-branch
+
+# you can set a const fake data if you need to test running tests on 2 CI nodes for the same commit/branch
+#COMMIT_HASH=57dccc53cb2ee921692ad1d3df971674
+
+# must be exported to read value in below knapsack_pro command
+export KNAPSACK_PRO_CI_NODE_INDEX=${1:-0}
+
+#export KNAPSACK_PRO_FIXED_QUEUE_SPLIT=true
+
+export EXTRA_TEST_FILES_DELAY=10 # seconds
+
+KNAPSACK_PRO_ENDPOINT=http://api.knapsackpro.test:3000 \
+  KNAPSACK_PRO_TEST_SUITE_TOKEN_RSPEC=fec3c641a3c4d2e720fe1b6d9dd780bc \
+  KNAPSACK_PRO_CI_NODE_BUILD_ID=$CI_BUILD_ID \
+  KNAPSACK_PRO_COMMIT_HASH=${3:-$COMMIT_HASH} \
+  KNAPSACK_PRO_BRANCH=$BRANCH_NAME \
+  KNAPSACK_PRO_CI_NODE_TOTAL=${2:-2} \
+  KNAPSACK_PRO_RSPEC_SPLIT_BY_TEST_EXAMPLES=true \
+  bundle exec rake "knapsack_pro:queue:rspec[--format documentation --format RspecJunitFormatter --out tmp/test-reports/rspec/first_run_junit_queue_mode/rspec_$KNAPSACK_PRO_CI_NODE_INDEX.xml]"

--- a/bin/knapsack_pro_queue_rspec_record_first_run_junit
+++ b/bin/knapsack_pro_queue_rspec_record_first_run_junit
@@ -31,6 +31,9 @@ export KNAPSACK_PRO_CI_NODE_INDEX=${1:-0}
 
 export EXTRA_TEST_FILES_DELAY=10 # seconds
 
+# uncomment to run all tests split by examples
+export KNAPSACK_PRO_SLOW_TEST_FILE_PATTERN="spec/**{,/*/**}/*_spec.rb"
+
 KNAPSACK_PRO_ENDPOINT=http://api.knapsackpro.test:3000 \
   KNAPSACK_PRO_TEST_SUITE_TOKEN_RSPEC=fec3c641a3c4d2e720fe1b6d9dd780bc \
   KNAPSACK_PRO_CI_NODE_BUILD_ID=$CI_BUILD_ID \

--- a/bin/knapsack_pro_queue_rspec_record_first_run_junit
+++ b/bin/knapsack_pro_queue_rspec_record_first_run_junit
@@ -13,7 +13,7 @@
 # CI node 1 for commit-v2
 # bin/knapsack_pro_queue_rspec_record_first_run_junit 1 2 commit-v1 ci-build-1
 
-mkdir -p tmp/test-reports/rspec/first_run_junit_queue_mode/
+mkdir -p tmp/test-reports/rspec/queue_mode/
 
 RANDOM_CI_BUILD_ID=$(openssl rand -base64 32)
 CI_BUILD_ID=${3:-$RANDOM_CI_BUILD_ID}
@@ -38,4 +38,4 @@ KNAPSACK_PRO_ENDPOINT=http://api.knapsackpro.test:3000 \
   KNAPSACK_PRO_BRANCH=$BRANCH_NAME \
   KNAPSACK_PRO_CI_NODE_TOTAL=${2:-2} \
   KNAPSACK_PRO_RSPEC_SPLIT_BY_TEST_EXAMPLES=true \
-  bundle exec rake "knapsack_pro:queue:rspec[--format documentation --format RspecJunitFormatter --out tmp/test-reports/rspec/first_run_junit_queue_mode/rspec_$KNAPSACK_PRO_CI_NODE_INDEX.xml]"
+  bundle exec rake "knapsack_pro:queue:rspec[--format documentation --format RspecJunitFormatter --out tmp/test-reports/rspec/queue_mode/rspec_$KNAPSACK_PRO_CI_NODE_INDEX.xml]"

--- a/spec/controllers/articles_controller_spec.rb
+++ b/spec/controllers/articles_controller_spec.rb
@@ -15,7 +15,7 @@ describe ArticlesController, :xfocus do
       get :index
     end
 
-    it do
+    it 'assigns the article' do
       expect(assigns(:articles)).to eq articles
     end
 


### PR DESCRIPTION
We use `bin/knapsack_pro_queue_rspec_record_first_run_junit` script to run tests for a new CI build in Queue Mode with enabled the RSpec split by test examples feature.

We split all test files by examples on purpose in order to catch edge cases when test examples could not be executed.by RSpec.

# knapsack_pro 6.0.3

**Result:** All test cases are executed (50/50 good)

```
ruby bin/collect_junit_xml_reports.rb > tmp/junit_test_cases_summary.txt && cat tmp/junit_test_cases_summary.txt

spec.async.reactor_spec, Async::IO should send and receive data within the same reactor
spec.bar_spec, Bar is expected to be a kind of Article(id: integer, title: string, body: text, created_at: datetime, updated_at: datetime)
spec.collection_spec, Array behaves like a collection #include? with an an item that is in the collection returns true
spec.collection_spec, Array behaves like a collection #include? with an an item that is not in the collection returns false
spec.collection_spec, Array behaves like a collection initialized with 3 items says it has three items
spec.collection_spec, MyArray initialized with 3 items says it has three items
spec.collection_spec, MyArray#include? with an an item that is in the collection returns true
spec.collection_spec, MyArray#include? with an an item that is not in the collection returns false
spec.collection_spec, MySet it should behave like a collection #include? with an an item that is in the collection returns true
spec.collection_spec, MySet it should behave like a collection #include? with an an item that is not in the collection returns false
spec.collection_spec, MySet it should behave like a collection initialized with 3 items says it has three items
spec.collection_spec, Set behaves like a collection #include? with an an item that is in the collection returns true
spec.collection_spec, Set behaves like a collection #include? with an an item that is not in the collection returns false
spec.collection_spec, Set behaves like a collection initialized with 3 items says it has three items
spec.controllers.articles_controller_spec, ArticlesController#index assigns the article
spec.controllers.articles_controller_spec, ArticlesController#index is expected to be successful
spec.controllers.articles_controller_spec, ArticlesController#show is expected to be successful
spec.controllers.dashboard.pending_controller_spec, PendingController
spec.controllers.pending_controller_spec, PendingController
spec.controllers.welcome_controller_spec, WelcomeController#index is expected to be successful
spec.dir with spaces.foobar_spec, FooBar is expected to equal true
spec.features.calculator_spec, Calculator Page when add two numbers result is 0
spec.features.calculator_spec, Calculator Page when add two numbers this must fail
spec.features.calculator_spec, Calculator Page when try to add without provided numbers result is 0
spec.features.homepage_spec, Homepage Features has link to calculator page
spec.features.homepage_spec, Homepage Features has welcome text
spec.foo_spec, Foo is expected to equal true
spec.options_spec, RSpec Options is expected to eq :automatic
spec.pending_spec, Pending
spec.rake_tasks.dummy_rake_spec, Dummy rake dummy:do_something_once calls the rake task once (increases counter by one)
spec.rake_tasks.dummy_rake_spec, Dummy rake dummy:do_something_once calls the rake task once again (increases counter by one)
spec.retry_spec, Retry should fail always
spec.retry_spec, Retry should randomly succeed
spec.services.calculator_spec, Calculator behaves like calculator behaves like has add method add is true
spec.services.calculator_spec, Calculator behaves like calculator behaves like has mal method mal is true
spec.services.calculator_spec, Calculator#add is expected to eq 5
spec.services.calculator_spec, Calculator#mal is expected to eq 6
spec.services.meme_spec, Meme#i_can_has_cheezburger? is expected to eq "OHAI!"
spec.services.meme_spec, Meme#will_it_blend? is expected to eq "YES!"
spec.slow_shared_examples_spec, Example of slow shared examples behaves like slow shared example test is expected to equal true
spec.slow_shared_examples_spec, Example of slow shared examples is expected to equal true
spec.system_exit_spec, SystemExit is expected to equal true
spec.time_helpers_spec, Time travel with ActiveSupport::Testing::TimeHelpers travel_back is expected to eq 2004
spec.time_helpers_spec, Time travel with ActiveSupport::Testing::TimeHelpers travel_to block 2014 is expected to eq 2004
spec.time_helpers_spec, Time travel with ActiveSupport::Testing::TimeHelpers travel_to block is expected to eq 20
spec.timecop_spec, Timecop travel in time
spec.timecop_spec, Timecop when stub Time
spec.track_context_time_spec, Track context time when something test 1
spec.track_context_time_spec, Track context time when something test 2
spec.vcr_spec, VCR is expected to include "Example domains"

Test cases: 50
```

## CI node 0

```
➜  rails-app-with-knapsack_pro git:(junit-reports) ✗ bin/knapsack_pro_queue_rspec_record_first_run_junit 0 2 ks603-v2 ci-build-8
D, [2023-12-21T15:30:50.657459 #74249] DEBUG -- : [knapsack_pro] Detected 24 slow test files: [{"path"=>"spec/async/reactor_spec.rb"}, {"path"=>"spec/bar_spec.rb"}, {"path"=>"spec/collection_spec.rb"}, {"path"=>"spec/controllers/articles_controller_spec.rb"}, {"path"=>"spec/controllers/dashboard/pending_controller_spec.rb"}, {"path"=>"spec/controllers/pending_controller_spec.rb"}, {"path"=>"spec/controllers/shared_articles_controller_spec.rb"}, {"path"=>"spec/controllers/welcome_controller_spec.rb"}, {"path"=>"spec/dir with spaces/foobar_spec.rb"}, {"path"=>"spec/features/calculator_spec.rb"}, {"path"=>"spec/features/homepage_spec.rb"}, {"path"=>"spec/foo_spec.rb"}, {"path"=>"spec/options_spec.rb"}, {"path"=>"spec/pending_spec.rb"}, {"path"=>"spec/rake_tasks/dummy_rake_spec.rb"}, {"path"=>"spec/retry_spec.rb"}, {"path"=>"spec/services/calculator_spec.rb"}, {"path"=>"spec/services/meme_spec.rb"}, {"path"=>"spec/slow_shared_examples_spec.rb"}, {"path"=>"spec/system_exit_spec.rb"}, {"path"=>"spec/time_helpers_spec.rb"}, {"path"=>"spec/timecop_spec.rb"}, {"path"=>"spec/track_context_time_spec.rb"}, {"path"=>"spec/vcr_spec.rb"}]
I, [2023-12-21T15:30:50.657643 #74249]  INFO -- : [knapsack_pro] Generating RSpec test examples JSON report for slow test files to prepare it to be split by test examples (by individual test cases). Thanks to that, a single slow test file can be split across parallel CI nodes. Analyzing 24 slow test files.
D, [2023-12-21T15:30:52.194643 #74257] DEBUG -- : [knapsack_pro] Test suite time execution queue recording enabled.
++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
CUSTOM_VARIABLE_FOR_RSPEC_TEST_EXAMPLE_DETECTOR is not set
rspec pid: 74257
Coverage report generated for RSpec, rspec_ci_node_0, rspec_ci_node_1 to /Users/artur/Documents/github/knapsack-pro/rails-app-with-knapsack_pro/coverage. 354 / 412 LOC (85.92%) covered.
I, [2023-12-21T15:30:52.870824 #74249]  INFO -- : [knapsack_pro] KNAPSACK_PRO_FIXED_QUEUE_SPLIT is not set. Using default value: true. Learn more at https://knapsackpro.com/perma/ruby/fixed-queue-split
D, [2023-12-21T15:30:52.945471 #74249] DEBUG -- : [knapsack_pro] POST http://api.knapsackpro.test:3000/v1/queues/queue
D, [2023-12-21T15:30:52.945492 #74249] DEBUG -- : [knapsack_pro] API request UUID: cb82c69a-78c1-4c65-b162-50e647df6389
D, [2023-12-21T15:30:52.945504 #74249] DEBUG -- : [knapsack_pro] API response:
D, [2023-12-21T15:30:52.945525 #74249] DEBUG -- : [knapsack_pro] {"queue_name"=>"130:8f81841dfd64325d5f6bac73642eda8a", "build_subset_id"=>nil, "test_files"=>[{"path"=>"spec/controllers/shared.rb[1:1:1:1:1]", "time_execution"=>0.0}]}
D, [2023-12-21T15:30:53.004215 #74249] DEBUG -- : [knapsack_pro] Test suite time execution queue recording enabled.
++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
CUSTOM_VARIABLE_FOR_RSPEC_TEST_EXAMPLE_DETECTOR is not set
rspec pid: 74249
Run options: include {:ids=>{"./spec/controllers/shared.rb"=>["1:1:1:1:1"]}}

All examples were filtered out
++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
RSpec before suite hook called only once
Run this only when using Knapsack Pro Queue Mode
This code is executed within the context of RSpec before(:suite) hook
----------Before Queue Hook - run before test suite----------
2nd KnapsackPro::Hooks::Queue.before_queue
before suite
after suite
D, [2023-12-21T15:30:53.510760 #74249] DEBUG -- : [knapsack_pro] Global time execution for tests: 0.012263000011444092s

I, [2023-12-21T15:30:53.512664 #74249]  INFO -- : [knapsack_pro] To retry the last batch of tests fetched from the API Queue, please run the following command on your machine:
I, [2023-12-21T15:30:53.512684 #74249]  INFO -- : [knapsack_pro] bundle exec rspec --format documentation --format RspecJunitFormatter --out tmp/test-reports/rspec/queue_mode/rspec_0.xml --default-path spec "spec/controllers/shared.rb[1:1:1:1:1]"
----------After Subset Queue Hook - run after the subset of the test suite----------
2nd KnapsackPro::Hooks::Queue.after_subset_queue
D, [2023-12-21T15:30:53.533592 #74249] DEBUG -- : [knapsack_pro] POST http://api.knapsackpro.test:3000/v1/queues/queue
D, [2023-12-21T15:30:53.533610 #74249] DEBUG -- : [knapsack_pro] API request UUID: e84c5178-19b2-47ed-b77d-1da65431b412
D, [2023-12-21T15:30:53.533620 #74249] DEBUG -- : [knapsack_pro] API response:
D, [2023-12-21T15:30:53.533635 #74249] DEBUG -- : [knapsack_pro] {"queue_name"=>"130:8f81841dfd64325d5f6bac73642eda8a", "build_subset_id"=>nil, "test_files"=>[{"path"=>"spec/retry_spec.rb[1:2]", "time_execution"=>0.0}]}
----------Before Subset Queue Hook - run before the subset of the test suite----------
2nd KnapsackPro::Hooks::Queue.before_subset_queue
Run options: include {:ids=>{"./spec/retry_spec.rb"=>["1:2"]}}
before suite

Retry
before all
  should fail always (PENDING: Temporarily skipped with xit)
after all
after suite
D, [2023-12-21T15:30:53.548648 #74249] DEBUG -- : [knapsack_pro] Global time execution for tests: 0.037832000060006976s

I, [2023-12-21T15:30:53.550655 #74249]  INFO -- : [knapsack_pro] To retry the last batch of tests fetched from the API Queue, please run the following command on your machine:
I, [2023-12-21T15:30:53.550676 #74249]  INFO -- : [knapsack_pro] bundle exec rspec --format documentation --format RspecJunitFormatter --out tmp/test-reports/rspec/queue_mode/rspec_0.xml --default-path spec "spec/retry_spec.rb[1:2]"
----------After Subset Queue Hook - run after the subset of the test suite----------
2nd KnapsackPro::Hooks::Queue.after_subset_queue
D, [2023-12-21T15:30:53.576446 #74249] DEBUG -- : [knapsack_pro] POST http://api.knapsackpro.test:3000/v1/queues/queue
D, [2023-12-21T15:30:53.576469 #74249] DEBUG -- : [knapsack_pro] API request UUID: d14bf211-4ac3-4625-a0ad-ab4cbcb8aad6
D, [2023-12-21T15:30:53.576477 #74249] DEBUG -- : [knapsack_pro] API response:
D, [2023-12-21T15:30:53.576493 #74249] DEBUG -- : [knapsack_pro] {"queue_name"=>"130:8f81841dfd64325d5f6bac73642eda8a", "build_subset_id"=>nil, "test_files"=>[{"path"=>"spec/slow_shared_examples_spec.rb[1:2]", "time_execution"=>11.0408669998869}]}
----------Before Subset Queue Hook - run before the subset of the test suite----------
2nd KnapsackPro::Hooks::Queue.before_subset_queue
Run options: include {:ids=>{"./spec/slow_shared_examples_spec.rb"=>["1:2"]}}
before suite

Example of slow shared examples
before all
around each start
before each
after each
around each stop
  is expected to equal true
after all
after suite
D, [2023-12-21T15:31:04.622876 #74249] DEBUG -- : [knapsack_pro] Global time execution for tests: 11s

I, [2023-12-21T15:31:04.625075 #74249]  INFO -- : [knapsack_pro] To retry the last batch of tests fetched from the API Queue, please run the following command on your machine:
I, [2023-12-21T15:31:04.625095 #74249]  INFO -- : [knapsack_pro] bundle exec rspec --format documentation --format RspecJunitFormatter --out tmp/test-reports/rspec/queue_mode/rspec_0.xml --default-path spec "spec/slow_shared_examples_spec.rb[1:2]"
----------After Subset Queue Hook - run after the subset of the test suite----------
2nd KnapsackPro::Hooks::Queue.after_subset_queue
D, [2023-12-21T15:31:04.646035 #74249] DEBUG -- : [knapsack_pro] POST http://api.knapsackpro.test:3000/v1/queues/queue
D, [2023-12-21T15:31:04.646058 #74249] DEBUG -- : [knapsack_pro] API request UUID: 3f514700-f39f-47d6-8a11-dddf905e81e6
D, [2023-12-21T15:31:04.646068 #74249] DEBUG -- : [knapsack_pro] API response:
D, [2023-12-21T15:31:04.646090 #74249] DEBUG -- : [knapsack_pro] {"queue_name"=>"130:8f81841dfd64325d5f6bac73642eda8a", "build_subset_id"=>nil, "test_files"=>[{"path"=>"spec/track_context_time_spec.rb[1:1:2]", "time_execution"=>5.41057499998715}]}
----------Before Subset Queue Hook - run before the subset of the test suite----------
2nd KnapsackPro::Hooks::Queue.before_subset_queue
Run options: include {:ids=>{"./spec/track_context_time_spec.rb"=>["1:1:2"]}}
before suite

Track context time
before all
  when something
around each start
before each
after each
around each stop
    test 2
after all
after suite
D, [2023-12-21T15:31:10.075946 #74249] DEBUG -- : [knapsack_pro] Global time execution for tests: 05s

I, [2023-12-21T15:31:10.096566 #74249]  INFO -- : [knapsack_pro] To retry the last batch of tests fetched from the API Queue, please run the following command on your machine:
I, [2023-12-21T15:31:10.096674 #74249]  INFO -- : [knapsack_pro] bundle exec rspec --format documentation --format RspecJunitFormatter --out tmp/test-reports/rspec/queue_mode/rspec_0.xml --default-path spec "spec/track_context_time_spec.rb[1:1:2]"
----------After Subset Queue Hook - run after the subset of the test suite----------
2nd KnapsackPro::Hooks::Queue.after_subset_queue
D, [2023-12-21T15:31:10.127574 #74249] DEBUG -- : [knapsack_pro] POST http://api.knapsackpro.test:3000/v1/queues/queue
D, [2023-12-21T15:31:10.127599 #74249] DEBUG -- : [knapsack_pro] API request UUID: 3c077593-f9a1-44b5-8c10-f79fc7ef2cfd
D, [2023-12-21T15:31:10.127612 #74249] DEBUG -- : [knapsack_pro] API response:
D, [2023-12-21T15:31:10.127644 #74249] DEBUG -- : [knapsack_pro] {"queue_name"=>"130:8f81841dfd64325d5f6bac73642eda8a", "build_subset_id"=>nil, "test_files"=>[{"path"=>"spec/time_helpers_spec.rb[1:1:1]", "time_execution"=>1.00791499996558}, {"path"=>"spec/time_helpers_spec.rb[1:2:1]", "time_execution"=>1.00612999987788}]}
----------Before Subset Queue Hook - run before the subset of the test suite----------
2nd KnapsackPro::Hooks::Queue.before_subset_queue
Run options: include {:ids=>{"./spec/time_helpers_spec.rb"=>["1:1:1", "1:2:1"]}}
before suite

Time travel with ActiveSupport::Testing::TimeHelpers
before all
  travel_back
around each start
before each
after each
around each stop
    is expected to eq 2004
  travel_to block
around each start
before each
after each
around each stop
    is expected to eq 20
after all
after suite
D, [2023-12-21T15:31:12.171222 #74249] DEBUG -- : [knapsack_pro] Global time execution for tests: 02s

I, [2023-12-21T15:31:12.186580 #74249]  INFO -- : [knapsack_pro] To retry the last batch of tests fetched from the API Queue, please run the following command on your machine:
I, [2023-12-21T15:31:12.186781 #74249]  INFO -- : [knapsack_pro] bundle exec rspec --format documentation --format RspecJunitFormatter --out tmp/test-reports/rspec/queue_mode/rspec_0.xml --default-path spec "spec/time_helpers_spec.rb[1:1:1]" "spec/time_helpers_spec.rb[1:2:1]"
----------After Subset Queue Hook - run after the subset of the test suite----------
2nd KnapsackPro::Hooks::Queue.after_subset_queue
D, [2023-12-21T15:31:12.230166 #74249] DEBUG -- : [knapsack_pro] POST http://api.knapsackpro.test:3000/v1/queues/queue
D, [2023-12-21T15:31:12.230196 #74249] DEBUG -- : [knapsack_pro] API request UUID: 892f46a0-4019-410d-a6ff-1064ccc8e163
D, [2023-12-21T15:31:12.230209 #74249] DEBUG -- : [knapsack_pro] API response:
D, [2023-12-21T15:31:12.230234 #74249] DEBUG -- : [knapsack_pro] {"queue_name"=>"130:8f81841dfd64325d5f6bac73642eda8a", "build_subset_id"=>nil, "test_files"=>[{"path"=>"spec/time_helpers_spec.rb[1:3:1]", "time_execution"=>1.00359199987724}]}
----------Before Subset Queue Hook - run before the subset of the test suite----------
2nd KnapsackPro::Hooks::Queue.before_subset_queue
Run options: include {:ids=>{"./spec/time_helpers_spec.rb"=>["1:3:1"]}}
before suite

Time travel with ActiveSupport::Testing::TimeHelpers
before all
  travel_to block 2014
around each start
before each
after each
around each stop
    is expected to eq 2004
after all
after suite
D, [2023-12-21T15:31:13.250677 #74249] DEBUG -- : [knapsack_pro] Global time execution for tests: 01s

I, [2023-12-21T15:31:13.254303 #74249]  INFO -- : [knapsack_pro] To retry the last batch of tests fetched from the API Queue, please run the following command on your machine:
I, [2023-12-21T15:31:13.254336 #74249]  INFO -- : [knapsack_pro] bundle exec rspec --format documentation --format RspecJunitFormatter --out tmp/test-reports/rspec/queue_mode/rspec_0.xml --default-path spec "spec/time_helpers_spec.rb[1:3:1]"
----------After Subset Queue Hook - run after the subset of the test suite----------
2nd KnapsackPro::Hooks::Queue.after_subset_queue
D, [2023-12-21T15:31:13.277375 #74249] DEBUG -- : [knapsack_pro] POST http://api.knapsackpro.test:3000/v1/queues/queue
D, [2023-12-21T15:31:13.277394 #74249] DEBUG -- : [knapsack_pro] API request UUID: 749ac974-2d89-4875-820d-7fbef58e1f0d
D, [2023-12-21T15:31:13.277404 #74249] DEBUG -- : [knapsack_pro] API response:
D, [2023-12-21T15:31:13.277482 #74249] DEBUG -- : [knapsack_pro] {"queue_name"=>"130:8f81841dfd64325d5f6bac73642eda8a", "build_subset_id"=>nil, "test_files"=>[{"path"=>"spec/collection_spec.rb[1:1:2:1:1]", "time_execution"=>0.00280000001657754}, {"path"=>"spec/collection_spec.rb[2:1:2:2:1]", "time_execution"=>0.00254999997559935}, {"path"=>"spec/services/calculator_spec.rb[1:1:1:1]", "time_execution"=>0.00236999988555908}, {"path"=>"spec/rake_tasks/dummy_rake_spec.rb[1:1:1]", "time_execution"=>0.00231500004883856}]}
----------Before Subset Queue Hook - run before the subset of the test suite----------
2nd KnapsackPro::Hooks::Queue.before_subset_queue
Run options: include {:ids=>{"./spec/collection_spec.rb"=>["1:1:2:1:1", "2:1:2:2:1"], "./spec/services/calculator_spec.rb"=>["1:1:1:1"], "./spec/rake_tasks/dummy_rake_spec.rb"=>["1:1:1"]}}
before suite

Array
before all
  behaves like a collection
    #include?
      with an an item that is in the collection
around each start
before each
after each
around each stop
        returns true
after all

Set
before all
  behaves like a collection
    #include?
      with an an item that is not in the collection
around each start
before each
after each
around each stop
        returns false
after all

Calculator
before all
  behaves like calculator
    behaves like has add method
around each start
before each
after each
around each stop
      add is true
after all

Dummy rake
before all
  dummy:do_something_once
around each start
before each
Count: 1
after each
around each stop
    calls the rake task once (increases counter by one)
after all
after suite
D, [2023-12-21T15:31:13.300665 #74249] DEBUG -- : [knapsack_pro] Global time execution for tests: 0.049943999969400465s

I, [2023-12-21T15:31:13.305007 #74249]  INFO -- : [knapsack_pro] To retry the last batch of tests fetched from the API Queue, please run the following command on your machine:
I, [2023-12-21T15:31:13.305028 #74249]  INFO -- : [knapsack_pro] bundle exec rspec --format documentation --format RspecJunitFormatter --out tmp/test-reports/rspec/queue_mode/rspec_0.xml --default-path spec "spec/collection_spec.rb[1:1:2:1:1]" "spec/collection_spec.rb[2:1:2:2:1]" "spec/services/calculator_spec.rb[1:1:1:1]" "spec/rake_tasks/dummy_rake_spec.rb[1:1:1]"
----------After Subset Queue Hook - run after the subset of the test suite----------
2nd KnapsackPro::Hooks::Queue.after_subset_queue
D, [2023-12-21T15:31:13.331212 #74249] DEBUG -- : [knapsack_pro] POST http://api.knapsackpro.test:3000/v1/queues/queue
D, [2023-12-21T15:31:13.331231 #74249] DEBUG -- : [knapsack_pro] API request UUID: dcd70648-d94d-4755-9f7f-f716d2d53067
D, [2023-12-21T15:31:13.331242 #74249] DEBUG -- : [knapsack_pro] API response:
D, [2023-12-21T15:31:13.331295 #74249] DEBUG -- : [knapsack_pro] {"queue_name"=>"130:8f81841dfd64325d5f6bac73642eda8a", "build_subset_id"=>nil, "test_files"=>[{"path"=>"spec/collection_spec.rb[1:1:2:2:1]", "time_execution"=>0.000910000060684979}, {"path"=>"spec/foo_spec.rb[1:1]", "time_execution"=>0.000899999984540045}, {"path"=>"spec/collection_spec.rb[2:1:2:1:1]", "time_execution"=>0.000865999958477914}, {"path"=>"spec/services/meme_spec.rb[1:2:1]", "time_execution"=>0.000849999953061342}, {"path"=>"spec/services/calculator_spec.rb[1:3:1]", "time_execution"=>0.000843999907374382}, {"path"=>"spec/collection_spec.rb[3:1:1]", "time_execution"=>0.000720999902114272}, {"path"=>"spec/collection_spec.rb[4:1:2:1:1]", "time_execution"=>0.000644000014290214}, {"path"=>"spec/options_spec.rb[1:1]", "time_execution"=>0.000644000014290214}, {"path"=>"spec/services/calculator_spec.rb[1:1:2:1]", "time_execution"=>0.000633000046946108}, {"path"=>"spec/retry_spec.rb[1:1]", "time_execution"=>0.000607999972999096}, {"path"=>"spec/system_exit_spec.rb[1:1]", "time_execution"=>0.000577999977394938}, {"path"=>"spec/collection_spec.rb[4:1:2:2:1]", "time_execution"=>0.000574000063352287}, {"path"=>"spec/collection_spec.rb[3:2:1:1]", "time_execution"=>0.000566999893635511}, {"path"=>"spec/collection_spec.rb[2:1:1:1]", "time_execution"=>0.000551999895833433}, {"path"=>"spec/collection_spec.rb[3:2:2:1]", "time_execution"=>0.000519999885000288}]}
----------Before Subset Queue Hook - run before the subset of the test suite----------
2nd KnapsackPro::Hooks::Queue.before_subset_queue
WARNING: Shared example group 'a collection' has been previously defined at:
  /Users/artur/Documents/github/knapsack-pro/rails-app-with-knapsack_pro/spec/collection_spec.rb:3
...and you are now defining it at:
  /Users/artur/Documents/github/knapsack-pro/rails-app-with-knapsack_pro/spec/collection_spec.rb:3
The new definition will overwrite the original one.
Run options: include {:ids=>{"./spec/collection_spec.rb"=>["1:1:2:2:1", "2:1:2:1:1", "3:1:1", "4:1:2:1:1", "4:1:2:2:1", "3:2:1:1", "2:1:1:1", "3:2:2:1"], "./spec/foo_spec.rb"=>["1:1"], "./spec/services/meme_spec.rb"=>["1:2:1"], "./spec/services/calculator_spec.rb"=>["1:3:1", "1:1:2:1"], "./spec/options_spec.rb"=>["1:1"], "./spec/retry_spec.rb"=>["1:1"], "./spec/system_exit_spec.rb"=>["1:1"]}}
before suite

Array
before all
  behaves like a collection
    #include?
      with an an item that is not in the collection
around each start
before each
after each
around each stop
        returns false
after all

Set
before all
  behaves like a collection
    initialized with 3 items
around each start
before each
after each
around each stop
      says it has three items
    #include?
      with an an item that is in the collection
around each start
before each
after each
around each stop
        returns true
after all

MyArray
before all
  initialized with 3 items
around each start
before each
after each
around each stop
    says it has three items
  #include?
    with an an item that is in the collection
around each start
before each
after each
around each stop
      returns true
    with an an item that is not in the collection
around each start
before each
after each
around each stop
      returns false
after all

MySet
before all
  it should behave like a collection
    #include?
      with an an item that is in the collection
around each start
before each
after each
around each stop
        returns true
      with an an item that is not in the collection
around each start
before each
after each
around each stop
        returns false
after all

Foo
before all
around each start
before each
after each
around each stop
  is expected to equal true
after all

Meme
before all
  #will_it_blend?
around each start
before each
after each
around each stop
    is expected to eq "YES!"
after all

Calculator
before all
  behaves like calculator
    behaves like has mal method
around each start
before each
after each
around each stop
      mal is true
  #mal
around each start
before each
after each
around each stop
    is expected to eq 6
after all

RSpec Options
before all
around each start
before each
after each
around each stop
  is expected to eq :automatic
after all

Retry
before all
around each start
before each
after each
around each stop
  should randomly succeed
after all

SystemExit
before all
around each start
before each
after each
around each stop
  is expected to equal true
after all
after suite
D, [2023-12-21T15:31:13.368947 #74249] DEBUG -- : [knapsack_pro] Global time execution for tests: 0.06822700006887317s

I, [2023-12-21T15:31:13.377152 #74249]  INFO -- : [knapsack_pro] To retry the last batch of tests fetched from the API Queue, please run the following command on your machine:
I, [2023-12-21T15:31:13.377179 #74249]  INFO -- : [knapsack_pro] bundle exec rspec --format documentation --format RspecJunitFormatter --out tmp/test-reports/rspec/queue_mode/rspec_0.xml --default-path spec "spec/collection_spec.rb[1:1:2:2:1]" "spec/foo_spec.rb[1:1]" "spec/collection_spec.rb[2:1:2:1:1]" "spec/services/meme_spec.rb[1:2:1]" "spec/services/calculator_spec.rb[1:3:1]" "spec/collection_spec.rb[3:1:1]" "spec/collection_spec.rb[4:1:2:1:1]" "spec/options_spec.rb[1:1]" "spec/services/calculator_spec.rb[1:1:2:1]" "spec/retry_spec.rb[1:1]" "spec/system_exit_spec.rb[1:1]" "spec/collection_spec.rb[4:1:2:2:1]" "spec/collection_spec.rb[3:2:1:1]" "spec/collection_spec.rb[2:1:1:1]" "spec/collection_spec.rb[3:2:2:1]"
----------After Subset Queue Hook - run after the subset of the test suite----------
2nd KnapsackPro::Hooks::Queue.after_subset_queue
D, [2023-12-21T15:31:13.396832 #74249] DEBUG -- : [knapsack_pro] POST http://api.knapsackpro.test:3000/v1/queues/queue
D, [2023-12-21T15:31:13.396850 #74249] DEBUG -- : [knapsack_pro] API request UUID: 43c8c368-7a04-4ac4-a052-f02ef3cdecf4
D, [2023-12-21T15:31:13.396860 #74249] DEBUG -- : [knapsack_pro] API response:
D, [2023-12-21T15:31:13.396872 #74249] DEBUG -- : [knapsack_pro] {"queue_name"=>"130:8f81841dfd64325d5f6bac73642eda8a", "build_subset_id"=>nil, "test_files"=>[]}
Knapsack Pro Queue finished!

All pending tests on this CI node:

Pending: (Failures listed here are expected and do not affect your suite's status)

  1) Retry should fail always
     # Temporarily skipped with xit
     # ./spec/retry_spec.rb:6



Finished in 19.87 seconds
25 examples, 0 failures, 1 pending
I, [2023-12-21T15:31:13.396941 #74249]  INFO -- : [knapsack_pro] To retry all the tests assigned to this CI node, please run the following command on your machine:
I, [2023-12-21T15:31:13.396961 #74249]  INFO -- : [knapsack_pro] bundle exec rspec --format documentation --format RspecJunitFormatter --out tmp/test-reports/rspec/queue_mode/rspec_0.xml --default-path spec "spec/controllers/shared.rb[1:1:1:1:1]" "spec/retry_spec.rb[1:2]" "spec/slow_shared_examples_spec.rb[1:2]" "spec/track_context_time_spec.rb[1:1:2]" "spec/time_helpers_spec.rb[1:1:1]" "spec/time_helpers_spec.rb[1:2:1]" "spec/time_helpers_spec.rb[1:3:1]" "spec/collection_spec.rb[1:1:2:1:1]" "spec/collection_spec.rb[2:1:2:2:1]" "spec/services/calculator_spec.rb[1:1:1:1]" "spec/rake_tasks/dummy_rake_spec.rb[1:1:1]" "spec/collection_spec.rb[1:1:2:2:1]" "spec/foo_spec.rb[1:1]" "spec/collection_spec.rb[2:1:2:1:1]" "spec/services/meme_spec.rb[1:2:1]" "spec/services/calculator_spec.rb[1:3:1]" "spec/collection_spec.rb[3:1:1]" "spec/collection_spec.rb[4:1:2:1:1]" "spec/options_spec.rb[1:1]" "spec/services/calculator_spec.rb[1:1:2:1]" "spec/retry_spec.rb[1:1]" "spec/system_exit_spec.rb[1:1]" "spec/collection_spec.rb[4:1:2:2:1]" "spec/collection_spec.rb[3:2:1:1]" "spec/collection_spec.rb[2:1:1:1]" "spec/collection_spec.rb[3:2:2:1]"
++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
after suite hook called only once
Run this only when using Knapsack Pro Queue Mode
This code is executed outside of the RSpec after(:suite) hook context because it's impossible to determine which after(:suite) is the last one to execute until it's executed.
----------After Queue Hook - run after test suite----------
2nd KnapsackPro::Hooks::Queue.after_queue
D, [2023-12-21T15:31:13.446583 #74249] DEBUG -- : [knapsack_pro] POST http://api.knapsackpro.test:3000/v1/build_subsets
D, [2023-12-21T15:31:13.446603 #74249] DEBUG -- : [knapsack_pro] API request UUID: 6a58218e-9dc3-406d-99f7-d098d69cacba
D, [2023-12-21T15:31:13.446613 #74249] DEBUG -- : [knapsack_pro] API response:
D, [2023-12-21T15:31:13.446620 #74249] DEBUG -- : [knapsack_pro]
D, [2023-12-21T15:31:13.446631 #74249] DEBUG -- : [knapsack_pro] Saved time execution report on Knapsack Pro API server.
Coverage report generated for RSpec, rspec_ci_node_0, rspec_ci_node_1 to /Users/artur/Documents/github/knapsack-pro/rails-app-with-knapsack_pro/coverage. 344 / 412 LOC (83.5%) covered.
```

## CI node 1

```
➜  rails-app-with-knapsack_pro git:(junit-reports) ✗ bin/knapsack_pro_queue_rspec_record_first_run_junit 1 2 ks603-v2 ci-build-8
D, [2023-12-21T15:30:50.384694 #74247] DEBUG -- : [knapsack_pro] Detected 24 slow test files: [{"path"=>"spec/async/reactor_spec.rb"}, {"path"=>"spec/bar_spec.rb"}, {"path"=>"spec/collection_spec.rb"}, {"path"=>"spec/controllers/articles_controller_spec.rb"}, {"path"=>"spec/controllers/dashboard/pending_controller_spec.rb"}, {"path"=>"spec/controllers/pending_controller_spec.rb"}, {"path"=>"spec/controllers/shared_articles_controller_spec.rb"}, {"path"=>"spec/controllers/welcome_controller_spec.rb"}, {"path"=>"spec/dir with spaces/foobar_spec.rb"}, {"path"=>"spec/features/calculator_spec.rb"}, {"path"=>"spec/features/homepage_spec.rb"}, {"path"=>"spec/foo_spec.rb"}, {"path"=>"spec/options_spec.rb"}, {"path"=>"spec/pending_spec.rb"}, {"path"=>"spec/rake_tasks/dummy_rake_spec.rb"}, {"path"=>"spec/retry_spec.rb"}, {"path"=>"spec/services/calculator_spec.rb"}, {"path"=>"spec/services/meme_spec.rb"}, {"path"=>"spec/slow_shared_examples_spec.rb"}, {"path"=>"spec/system_exit_spec.rb"}, {"path"=>"spec/time_helpers_spec.rb"}, {"path"=>"spec/timecop_spec.rb"}, {"path"=>"spec/track_context_time_spec.rb"}, {"path"=>"spec/vcr_spec.rb"}]
I, [2023-12-21T15:30:50.384865 #74247]  INFO -- : [knapsack_pro] Generating RSpec test examples JSON report for slow test files to prepare it to be split by test examples (by individual test cases). Thanks to that, a single slow test file can be split across parallel CI nodes. Analyzing 24 slow test files.
D, [2023-12-21T15:30:51.956356 #74253] DEBUG -- : [knapsack_pro] Test suite time execution queue recording enabled.
++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
CUSTOM_VARIABLE_FOR_RSPEC_TEST_EXAMPLE_DETECTOR is not set
rspec pid: 74253
Coverage report generated for RSpec, rspec_ci_node_0, rspec_ci_node_1 to /Users/artur/Documents/github/knapsack-pro/rails-app-with-knapsack_pro/coverage. 354 / 412 LOC (85.92%) covered.
I, [2023-12-21T15:30:52.610495 #74247]  INFO -- : [knapsack_pro] KNAPSACK_PRO_FIXED_QUEUE_SPLIT is not set. Using default value: true. Learn more at https://knapsackpro.com/perma/ruby/fixed-queue-split
D, [2023-12-21T15:30:52.690232 #74247] DEBUG -- : [knapsack_pro] POST http://api.knapsackpro.test:3000/v1/queues/queue
D, [2023-12-21T15:30:52.690257 #74247] DEBUG -- : [knapsack_pro] API request UUID: 47eef2c4-5d1f-4f57-9ca8-2e3e54e4c1dd
D, [2023-12-21T15:30:52.690268 #74247] DEBUG -- : [knapsack_pro] API response:
D, [2023-12-21T15:30:52.690292 #74247] DEBUG -- : [knapsack_pro] {"queue_name"=>"130:8f81841dfd64325d5f6bac73642eda8a:queue-must-be-initialized-first", "message"=>"A queue with a list of test files does not exist on the API side yet. If you see this message, everything works as expected. Now Knapsack Pro client will initialize a queue on the API side with a list of test files you want to run. The request to initialize the queue will have attributes like can_initialize_queue=true, attempt_connect_to_queue=false, and test_files, etc.", "code"=>"ATTEMPT_CONNECT_TO_QUEUE_FAILED"}
D, [2023-12-21T15:30:52.858193 #74247] DEBUG -- : [knapsack_pro] POST http://api.knapsackpro.test:3000/v1/queues/queue
D, [2023-12-21T15:30:52.858223 #74247] DEBUG -- : [knapsack_pro] API request UUID: 7d5c2752-783e-4b0d-ad33-13324d2d5d8f
D, [2023-12-21T15:30:52.858232 #74247] DEBUG -- : [knapsack_pro] API response:
D, [2023-12-21T15:30:52.858252 #74247] DEBUG -- : [knapsack_pro] {"queue_name"=>"130:8f81841dfd64325d5f6bac73642eda8a", "build_subset_id"=>nil, "test_files"=>[{"path"=>"spec/controllers/pending_controller_spec.rb[1:1]", "time_execution"=>0.0}]}
D, [2023-12-21T15:30:52.914576 #74247] DEBUG -- : [knapsack_pro] Test suite time execution queue recording enabled.
++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
CUSTOM_VARIABLE_FOR_RSPEC_TEST_EXAMPLE_DETECTOR is not set
rspec pid: 74247
Run options: include {:ids=>{"./spec/controllers/pending_controller_spec.rb"=>["1:1"]}}
++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
RSpec before suite hook called only once
Run this only when using Knapsack Pro Queue Mode
This code is executed within the context of RSpec before(:suite) hook
----------Before Queue Hook - run before test suite----------
2nd KnapsackPro::Hooks::Queue.before_queue
before suite

PendingController
before all
  example at ./spec/controllers/pending_controller_spec.rb:7 (PENDING: Temporarily skipped with xit)
after all
after suite
D, [2023-12-21T15:30:53.415216 #74247] DEBUG -- : [knapsack_pro] Global time execution for tests: 0.02259599999524653s

I, [2023-12-21T15:30:53.417405 #74247]  INFO -- : [knapsack_pro] To retry the last batch of tests fetched from the API Queue, please run the following command on your machine:
I, [2023-12-21T15:30:53.417435 #74247]  INFO -- : [knapsack_pro] bundle exec rspec --format documentation --format RspecJunitFormatter --out tmp/test-reports/rspec/queue_mode/rspec_1.xml --default-path spec "spec/controllers/pending_controller_spec.rb[1:1]"
----------After Subset Queue Hook - run after the subset of the test suite----------
2nd KnapsackPro::Hooks::Queue.after_subset_queue
D, [2023-12-21T15:30:53.441725 #74247] DEBUG -- : [knapsack_pro] POST http://api.knapsackpro.test:3000/v1/queues/queue
D, [2023-12-21T15:30:53.441755 #74247] DEBUG -- : [knapsack_pro] API request UUID: 0646ce02-4d4f-4194-8f7a-d88044fdd699
D, [2023-12-21T15:30:53.441766 #74247] DEBUG -- : [knapsack_pro] API response:
D, [2023-12-21T15:30:53.441786 #74247] DEBUG -- : [knapsack_pro] {"queue_name"=>"130:8f81841dfd64325d5f6bac73642eda8a", "build_subset_id"=>nil, "test_files"=>[{"path"=>"spec/pending_spec.rb[1:1]", "time_execution"=>0.0}]}
----------Before Subset Queue Hook - run before the subset of the test suite----------
2nd KnapsackPro::Hooks::Queue.before_subset_queue
Run options: include {:ids=>{"./spec/pending_spec.rb"=>["1:1"]}}
before suite

Pending
before all
  example at ./spec/pending_spec.rb:2 (PENDING: Temporarily skipped with xit)
after all
after suite
D, [2023-12-21T15:30:53.459625 #74247] DEBUG -- : [knapsack_pro] Global time execution for tests: 0.04435900005046278s

I, [2023-12-21T15:30:53.461793 #74247]  INFO -- : [knapsack_pro] To retry the last batch of tests fetched from the API Queue, please run the following command on your machine:
I, [2023-12-21T15:30:53.461810 #74247]  INFO -- : [knapsack_pro] bundle exec rspec --format documentation --format RspecJunitFormatter --out tmp/test-reports/rspec/queue_mode/rspec_1.xml --default-path spec "spec/pending_spec.rb[1:1]"
----------After Subset Queue Hook - run after the subset of the test suite----------
2nd KnapsackPro::Hooks::Queue.after_subset_queue
D, [2023-12-21T15:30:53.483240 #74247] DEBUG -- : [knapsack_pro] POST http://api.knapsackpro.test:3000/v1/queues/queue
D, [2023-12-21T15:30:53.483261 #74247] DEBUG -- : [knapsack_pro] API request UUID: 904d2df4-50b1-4252-9a0e-d298825756d8
D, [2023-12-21T15:30:53.483271 #74247] DEBUG -- : [knapsack_pro] API response:
D, [2023-12-21T15:30:53.483288 #74247] DEBUG -- : [knapsack_pro] {"queue_name"=>"130:8f81841dfd64325d5f6bac73642eda8a", "build_subset_id"=>nil, "test_files"=>[{"path"=>"spec/controllers/dashboard/pending_controller_spec.rb[1:1]", "time_execution"=>0.0}]}
----------Before Subset Queue Hook - run before the subset of the test suite----------
2nd KnapsackPro::Hooks::Queue.before_subset_queue
Run options: include {:ids=>{"./spec/controllers/dashboard/pending_controller_spec.rb"=>["1:1"]}}
before suite

PendingController
before all
  example at ./spec/controllers/dashboard/pending_controller_spec.rb:2 (PENDING: Temporarily skipped with xit)
after all
after suite
D, [2023-12-21T15:30:53.495173 #74247] DEBUG -- : [knapsack_pro] Global time execution for tests: 0.03550799994263798s

I, [2023-12-21T15:30:53.497306 #74247]  INFO -- : [knapsack_pro] To retry the last batch of tests fetched from the API Queue, please run the following command on your machine:
I, [2023-12-21T15:30:53.497325 #74247]  INFO -- : [knapsack_pro] bundle exec rspec --format documentation --format RspecJunitFormatter --out tmp/test-reports/rspec/queue_mode/rspec_1.xml --default-path spec "spec/controllers/dashboard/pending_controller_spec.rb[1:1]"
----------After Subset Queue Hook - run after the subset of the test suite----------
2nd KnapsackPro::Hooks::Queue.after_subset_queue
D, [2023-12-21T15:30:53.525061 #74247] DEBUG -- : [knapsack_pro] POST http://api.knapsackpro.test:3000/v1/queues/queue
D, [2023-12-21T15:30:53.525084 #74247] DEBUG -- : [knapsack_pro] API request UUID: 26904a00-497d-4ba2-9087-12d1d8c1eae7
D, [2023-12-21T15:30:53.525093 #74247] DEBUG -- : [knapsack_pro] API response:
D, [2023-12-21T15:30:53.525108 #74247] DEBUG -- : [knapsack_pro] {"queue_name"=>"130:8f81841dfd64325d5f6bac73642eda8a", "build_subset_id"=>nil, "test_files"=>[{"path"=>"spec/features/calculator_spec.rb[1:2:2]", "time_execution"=>0.0}]}
----------Before Subset Queue Hook - run before the subset of the test suite----------
2nd KnapsackPro::Hooks::Queue.before_subset_queue
Run options: include {:ids=>{"./spec/features/calculator_spec.rb"=>["1:2:2"]}}
before suite

Calculator Page
before all
  when add two numbers
    this must fail (PENDING: Temporarily skipped with xit)
after all
after suite
D, [2023-12-21T15:30:53.539998 #74247] DEBUG -- : [knapsack_pro] Global time execution for tests: 0.04478100000414997s

I, [2023-12-21T15:30:53.542580 #74247]  INFO -- : [knapsack_pro] To retry the last batch of tests fetched from the API Queue, please run the following command on your machine:
I, [2023-12-21T15:30:53.542598 #74247]  INFO -- : [knapsack_pro] bundle exec rspec --format documentation --format RspecJunitFormatter --out tmp/test-reports/rspec/queue_mode/rspec_1.xml --default-path spec "spec/features/calculator_spec.rb[1:2:2]"
----------After Subset Queue Hook - run after the subset of the test suite----------
2nd KnapsackPro::Hooks::Queue.after_subset_queue
D, [2023-12-21T15:30:53.562398 #74247] DEBUG -- : [knapsack_pro] POST http://api.knapsackpro.test:3000/v1/queues/queue
D, [2023-12-21T15:30:53.562422 #74247] DEBUG -- : [knapsack_pro] API request UUID: 5a784ed5-f56a-47b7-9d75-988bec98a168
D, [2023-12-21T15:30:53.562431 #74247] DEBUG -- : [knapsack_pro] API response:
D, [2023-12-21T15:30:53.562448 #74247] DEBUG -- : [knapsack_pro] {"queue_name"=>"130:8f81841dfd64325d5f6bac73642eda8a", "build_subset_id"=>nil, "test_files"=>[{"path"=>"spec/slow_shared_examples_spec.rb[1:1:1]", "time_execution"=>12.5501790000126}]}
----------Before Subset Queue Hook - run before the subset of the test suite----------
2nd KnapsackPro::Hooks::Queue.before_subset_queue
Run options: include {:ids=>{"./spec/slow_shared_examples_spec.rb"=>["1:1:1"]}}
before suite

Example of slow shared examples
before all
  behaves like slow shared example test
around each start
before each
after each
around each stop
    is expected to equal true
after all
after suite
D, [2023-12-21T15:31:06.115626 #74247] DEBUG -- : [knapsack_pro] Global time execution for tests: 12s

I, [2023-12-21T15:31:06.118984 #74247]  INFO -- : [knapsack_pro] To retry the last batch of tests fetched from the API Queue, please run the following command on your machine:
I, [2023-12-21T15:31:06.119026 #74247]  INFO -- : [knapsack_pro] bundle exec rspec --format documentation --format RspecJunitFormatter --out tmp/test-reports/rspec/queue_mode/rspec_1.xml --default-path spec "spec/slow_shared_examples_spec.rb[1:1:1]"
----------After Subset Queue Hook - run after the subset of the test suite----------
2nd KnapsackPro::Hooks::Queue.after_subset_queue
D, [2023-12-21T15:31:06.145758 #74247] DEBUG -- : [knapsack_pro] POST http://api.knapsackpro.test:3000/v1/queues/queue
D, [2023-12-21T15:31:06.145784 #74247] DEBUG -- : [knapsack_pro] API request UUID: 5ff03155-f43f-4e8a-a4e9-c3489c8cbd06
D, [2023-12-21T15:31:06.145795 #74247] DEBUG -- : [knapsack_pro] API response:
D, [2023-12-21T15:31:06.145817 #74247] DEBUG -- : [knapsack_pro] {"queue_name"=>"130:8f81841dfd64325d5f6bac73642eda8a", "build_subset_id"=>nil, "test_files"=>[{"path"=>"spec/track_context_time_spec.rb[1:1:1]", "time_execution"=>5.30979900003877}]}
----------Before Subset Queue Hook - run before the subset of the test suite----------
2nd KnapsackPro::Hooks::Queue.before_subset_queue
Run options: include {:ids=>{"./spec/track_context_time_spec.rb"=>["1:1:1"]}}
before suite

Track context time
before all
  when something
around each start
before each
after each
around each stop
    test 1
after all
after suite
D, [2023-12-21T15:31:11.483711 #74247] DEBUG -- : [knapsack_pro] Global time execution for tests: 05s

I, [2023-12-21T15:31:11.501752 #74247]  INFO -- : [knapsack_pro] To retry the last batch of tests fetched from the API Queue, please run the following command on your machine:
I, [2023-12-21T15:31:11.501977 #74247]  INFO -- : [knapsack_pro] bundle exec rspec --format documentation --format RspecJunitFormatter --out tmp/test-reports/rspec/queue_mode/rspec_1.xml --default-path spec "spec/track_context_time_spec.rb[1:1:1]"
----------After Subset Queue Hook - run after the subset of the test suite----------
2nd KnapsackPro::Hooks::Queue.after_subset_queue
D, [2023-12-21T15:31:11.554214 #74247] DEBUG -- : [knapsack_pro] POST http://api.knapsackpro.test:3000/v1/queues/queue
D, [2023-12-21T15:31:11.554249 #74247] DEBUG -- : [knapsack_pro] API request UUID: a0ab6e65-1154-45f0-8150-b5f3095a7443
D, [2023-12-21T15:31:11.554263 #74247] DEBUG -- : [knapsack_pro] API response:
D, [2023-12-21T15:31:11.554292 #74247] DEBUG -- : [knapsack_pro] {"queue_name"=>"130:8f81841dfd64325d5f6bac73642eda8a", "build_subset_id"=>nil, "test_files"=>[{"path"=>"spec/timecop_spec.rb[1:1]", "time_execution"=>1.00601899984758}]}
----------Before Subset Queue Hook - run before the subset of the test suite----------
2nd KnapsackPro::Hooks::Queue.before_subset_queue
Run options: include {:ids=>{"./spec/timecop_spec.rb"=>["1:1"]}}
before suite

Timecop
before all
around each start
before each
after each
around each stop
  travel in time
after all
after suite
D, [2023-12-21T15:31:12.586657 #74247] DEBUG -- : [knapsack_pro] Global time execution for tests: 01s

I, [2023-12-21T15:31:12.604486 #74247]  INFO -- : [knapsack_pro] To retry the last batch of tests fetched from the API Queue, please run the following command on your machine:
I, [2023-12-21T15:31:12.604616 #74247]  INFO -- : [knapsack_pro] bundle exec rspec --format documentation --format RspecJunitFormatter --out tmp/test-reports/rspec/queue_mode/rspec_1.xml --default-path spec "spec/timecop_spec.rb[1:1]"
----------After Subset Queue Hook - run after the subset of the test suite----------
2nd KnapsackPro::Hooks::Queue.after_subset_queue
D, [2023-12-21T15:31:12.655026 #74247] DEBUG -- : [knapsack_pro] POST http://api.knapsackpro.test:3000/v1/queues/queue
D, [2023-12-21T15:31:12.655077 #74247] DEBUG -- : [knapsack_pro] API request UUID: d0a10679-9540-4851-85be-72717fad8e03
D, [2023-12-21T15:31:12.655094 #74247] DEBUG -- : [knapsack_pro] API response:
D, [2023-12-21T15:31:12.655126 #74247] DEBUG -- : [knapsack_pro] {"queue_name"=>"130:8f81841dfd64325d5f6bac73642eda8a", "build_subset_id"=>nil, "test_files"=>[{"path"=>"spec/features/calculator_spec.rb[1:2:1]", "time_execution"=>0.121197000029497}]}
----------Before Subset Queue Hook - run before the subset of the test suite----------
2nd KnapsackPro::Hooks::Queue.before_subset_queue
Run options: include {:ids=>{"./spec/features/calculator_spec.rb"=>["1:2:1"]}}
before suite

Calculator Page
before all
  when add two numbers
around each start
before each
after each
around each stop
    result is 0
after all
after suite
D, [2023-12-21T15:31:12.780400 #74247] DEBUG -- : [knapsack_pro] Global time execution for tests: 0.19357599993236363s

I, [2023-12-21T15:31:12.796370 #74247]  INFO -- : [knapsack_pro] To retry the last batch of tests fetched from the API Queue, please run the following command on your machine:
I, [2023-12-21T15:31:12.798965 #74247]  INFO -- : [knapsack_pro] bundle exec rspec --format documentation --format RspecJunitFormatter --out tmp/test-reports/rspec/queue_mode/rspec_1.xml --default-path spec "spec/features/calculator_spec.rb[1:2:1]"
----------After Subset Queue Hook - run after the subset of the test suite----------
2nd KnapsackPro::Hooks::Queue.after_subset_queue
D, [2023-12-21T15:31:12.844630 #74247] DEBUG -- : [knapsack_pro] POST http://api.knapsackpro.test:3000/v1/queues/queue
D, [2023-12-21T15:31:12.844658 #74247] DEBUG -- : [knapsack_pro] API request UUID: ea9311e3-7c14-4a26-85cc-e4e3ee036bc1
D, [2023-12-21T15:31:12.844667 #74247] DEBUG -- : [knapsack_pro] API response:
D, [2023-12-21T15:31:12.844687 #74247] DEBUG -- : [knapsack_pro] {"queue_name"=>"130:8f81841dfd64325d5f6bac73642eda8a", "build_subset_id"=>nil, "test_files"=>[{"path"=>"spec/features/calculator_spec.rb[1:1:1]", "time_execution"=>0.0998970000073314}]}
----------Before Subset Queue Hook - run before the subset of the test suite----------
2nd KnapsackPro::Hooks::Queue.before_subset_queue
Run options: include {:ids=>{"./spec/features/calculator_spec.rb"=>["1:1:1"]}}
before suite

Calculator Page
before all
  when try to add without provided numbers
around each start
before each
after each
around each stop
    result is 0
after all
after suite
D, [2023-12-21T15:31:12.900019 #74247] DEBUG -- : [knapsack_pro] Global time execution for tests: 0.11957999994046986s

I, [2023-12-21T15:31:12.907071 #74247]  INFO -- : [knapsack_pro] To retry the last batch of tests fetched from the API Queue, please run the following command on your machine:
I, [2023-12-21T15:31:12.907106 #74247]  INFO -- : [knapsack_pro] bundle exec rspec --format documentation --format RspecJunitFormatter --out tmp/test-reports/rspec/queue_mode/rspec_1.xml --default-path spec "spec/features/calculator_spec.rb[1:1:1]"
----------After Subset Queue Hook - run after the subset of the test suite----------
2nd KnapsackPro::Hooks::Queue.after_subset_queue
D, [2023-12-21T15:31:12.931387 #74247] DEBUG -- : [knapsack_pro] POST http://api.knapsackpro.test:3000/v1/queues/queue
D, [2023-12-21T15:31:12.931413 #74247] DEBUG -- : [knapsack_pro] API request UUID: 6a7a0d88-fe3e-4bf6-9c68-f8d155d7d7e3
D, [2023-12-21T15:31:12.931424 #74247] DEBUG -- : [knapsack_pro] API response:
D, [2023-12-21T15:31:12.931444 #74247] DEBUG -- : [knapsack_pro] {"queue_name"=>"130:8f81841dfd64325d5f6bac73642eda8a", "build_subset_id"=>nil, "test_files"=>[{"path"=>"spec/async/reactor_spec.rb[1:1]", "time_execution"=>0.0728290000697598}]}
----------Before Subset Queue Hook - run before the subset of the test suite----------
2nd KnapsackPro::Hooks::Queue.before_subset_queue
Run options: include {:ids=>{"./spec/async/reactor_spec.rb"=>["1:1"]}}
before suite

Async::IO
before all
around each start
before each
after each
around each stop
  should send and receive data within the same reactor
after all
after suite
D, [2023-12-21T15:31:13.026167 #74247] DEBUG -- : [knapsack_pro] Global time execution for tests: 0.12609999999403954s

I, [2023-12-21T15:31:13.031156 #74247]  INFO -- : [knapsack_pro] To retry the last batch of tests fetched from the API Queue, please run the following command on your machine:
I, [2023-12-21T15:31:13.031172 #74247]  INFO -- : [knapsack_pro] bundle exec rspec --format documentation --format RspecJunitFormatter --out tmp/test-reports/rspec/queue_mode/rspec_1.xml --default-path spec "spec/async/reactor_spec.rb[1:1]"
----------After Subset Queue Hook - run after the subset of the test suite----------
2nd KnapsackPro::Hooks::Queue.after_subset_queue
D, [2023-12-21T15:31:13.052065 #74247] DEBUG -- : [knapsack_pro] POST http://api.knapsackpro.test:3000/v1/queues/queue
D, [2023-12-21T15:31:13.052088 #74247] DEBUG -- : [knapsack_pro] API request UUID: cd4ee1ed-da72-45a8-9f6b-8d5310ce5c10
D, [2023-12-21T15:31:13.052098 #74247] DEBUG -- : [knapsack_pro] API response:
D, [2023-12-21T15:31:13.052116 #74247] DEBUG -- : [knapsack_pro] {"queue_name"=>"130:8f81841dfd64325d5f6bac73642eda8a", "build_subset_id"=>nil, "test_files"=>[{"path"=>"spec/controllers/articles_controller_spec.rb[1:1:2]", "time_execution"=>0.0352309999288991}]}
----------Before Subset Queue Hook - run before the subset of the test suite----------
2nd KnapsackPro::Hooks::Queue.before_subset_queue
Run options: include {:ids=>{"./spec/controllers/articles_controller_spec.rb"=>["1:1:2"]}}
before suite

ArticlesController
before all
  #index
around each start
before each
after each
around each stop
    is expected to be successful
after all
after suite
D, [2023-12-21T15:31:13.087237 #74247] DEBUG -- : [knapsack_pro] Global time execution for tests: 0.06102700007613748s

I, [2023-12-21T15:31:13.093222 #74247]  INFO -- : [knapsack_pro] To retry the last batch of tests fetched from the API Queue, please run the following command on your machine:
I, [2023-12-21T15:31:13.093251 #74247]  INFO -- : [knapsack_pro] bundle exec rspec --format documentation --format RspecJunitFormatter --out tmp/test-reports/rspec/queue_mode/rspec_1.xml --default-path spec "spec/controllers/articles_controller_spec.rb[1:1:2]"
----------After Subset Queue Hook - run after the subset of the test suite----------
2nd KnapsackPro::Hooks::Queue.after_subset_queue
D, [2023-12-21T15:31:13.113559 #74247] DEBUG -- : [knapsack_pro] POST http://api.knapsackpro.test:3000/v1/queues/queue
D, [2023-12-21T15:31:13.113584 #74247] DEBUG -- : [knapsack_pro] API request UUID: 4b930b72-c631-4532-9be2-b22aa66eac76
D, [2023-12-21T15:31:13.113593 #74247] DEBUG -- : [knapsack_pro] API response:
D, [2023-12-21T15:31:13.113612 #74247] DEBUG -- : [knapsack_pro] {"queue_name"=>"130:8f81841dfd64325d5f6bac73642eda8a", "build_subset_id"=>nil, "test_files"=>[{"path"=>"spec/controllers/articles_controller_spec.rb[1:1:1]", "time_execution"=>0.0232710000127554}]}
----------Before Subset Queue Hook - run before the subset of the test suite----------
2nd KnapsackPro::Hooks::Queue.before_subset_queue
Run options: include {:ids=>{"./spec/controllers/articles_controller_spec.rb"=>["1:1:1"]}}
before suite

ArticlesController
before all
  #index
around each start
before each
after each
around each stop
    assigns the article
after all
after suite
D, [2023-12-21T15:31:13.136195 #74247] DEBUG -- : [knapsack_pro] Global time execution for tests: 0.04891799995675683s

I, [2023-12-21T15:31:13.142583 #74247]  INFO -- : [knapsack_pro] To retry the last batch of tests fetched from the API Queue, please run the following command on your machine:
I, [2023-12-21T15:31:13.142599 #74247]  INFO -- : [knapsack_pro] bundle exec rspec --format documentation --format RspecJunitFormatter --out tmp/test-reports/rspec/queue_mode/rspec_1.xml --default-path spec "spec/controllers/articles_controller_spec.rb[1:1:1]"
----------After Subset Queue Hook - run after the subset of the test suite----------
2nd KnapsackPro::Hooks::Queue.after_subset_queue
D, [2023-12-21T15:31:13.162377 #74247] DEBUG -- : [knapsack_pro] POST http://api.knapsackpro.test:3000/v1/queues/queue
D, [2023-12-21T15:31:13.162399 #74247] DEBUG -- : [knapsack_pro] API request UUID: 04b30751-86a6-498e-b0d2-ac6af98195fa
D, [2023-12-21T15:31:13.162408 #74247] DEBUG -- : [knapsack_pro] API response:
D, [2023-12-21T15:31:13.162434 #74247] DEBUG -- : [knapsack_pro] {"queue_name"=>"130:8f81841dfd64325d5f6bac73642eda8a", "build_subset_id"=>nil, "test_files"=>[{"path"=>"spec/vcr_spec.rb[1:1]", "time_execution"=>0.0166400000452995}, {"path"=>"spec/features/homepage_spec.rb[1:2]", "time_execution"=>0.0139600000111386}]}
----------Before Subset Queue Hook - run before the subset of the test suite----------
2nd KnapsackPro::Hooks::Queue.before_subset_queue
Run options: include {:ids=>{"./spec/vcr_spec.rb"=>["1:1"], "./spec/features/homepage_spec.rb"=>["1:2"]}}
before suite

VCR
before all
around each start
before each
after each
around each stop
  is expected to include "Example domains"
after all

Homepage Features
before all
around each start
before each
after each
around each stop
  has link to calculator page
after all
after suite
D, [2023-12-21T15:31:13.207353 #74247] DEBUG -- : [knapsack_pro] Global time execution for tests: 0.07111699995584786s

I, [2023-12-21T15:31:13.214313 #74247]  INFO -- : [knapsack_pro] To retry the last batch of tests fetched from the API Queue, please run the following command on your machine:
I, [2023-12-21T15:31:13.214329 #74247]  INFO -- : [knapsack_pro] bundle exec rspec --format documentation --format RspecJunitFormatter --out tmp/test-reports/rspec/queue_mode/rspec_1.xml --default-path spec "spec/vcr_spec.rb[1:1]" "spec/features/homepage_spec.rb[1:2]"
----------After Subset Queue Hook - run after the subset of the test suite----------
2nd KnapsackPro::Hooks::Queue.after_subset_queue
D, [2023-12-21T15:31:13.241402 #74247] DEBUG -- : [knapsack_pro] POST http://api.knapsackpro.test:3000/v1/queues/queue
D, [2023-12-21T15:31:13.241422 #74247] DEBUG -- : [knapsack_pro] API request UUID: a7d669df-676e-4f74-9f22-bf45ad1d4904
D, [2023-12-21T15:31:13.241431 #74247] DEBUG -- : [knapsack_pro] API response:
D, [2023-12-21T15:31:13.241449 #74247] DEBUG -- : [knapsack_pro] {"queue_name"=>"130:8f81841dfd64325d5f6bac73642eda8a", "build_subset_id"=>nil, "test_files"=>[{"path"=>"spec/features/homepage_spec.rb[1:1]", "time_execution"=>0.00942100002430379}, {"path"=>"spec/controllers/articles_controller_spec.rb[1:2:1]", "time_execution"=>0.00294499995652586}]}
----------Before Subset Queue Hook - run before the subset of the test suite----------
2nd KnapsackPro::Hooks::Queue.before_subset_queue
Run options: include {:ids=>{"./spec/features/homepage_spec.rb"=>["1:1"], "./spec/controllers/articles_controller_spec.rb"=>["1:2:1"]}}
before suite

Homepage Features
before all
around each start
before each
after each
around each stop
  has welcome text
after all

ArticlesController
before all
  #show
around each start
before each
after each
around each stop
    is expected to be successful
after all
after suite
D, [2023-12-21T15:31:13.271284 #74247] DEBUG -- : [knapsack_pro] Global time execution for tests: 0.06389000010676682s

I, [2023-12-21T15:31:13.284211 #74247]  INFO -- : [knapsack_pro] To retry the last batch of tests fetched from the API Queue, please run the following command on your machine:
I, [2023-12-21T15:31:13.284240 #74247]  INFO -- : [knapsack_pro] bundle exec rspec --format documentation --format RspecJunitFormatter --out tmp/test-reports/rspec/queue_mode/rspec_1.xml --default-path spec "spec/features/homepage_spec.rb[1:1]" "spec/controllers/articles_controller_spec.rb[1:2:1]"
----------After Subset Queue Hook - run after the subset of the test suite----------
2nd KnapsackPro::Hooks::Queue.after_subset_queue
D, [2023-12-21T15:31:13.312301 #74247] DEBUG -- : [knapsack_pro] POST http://api.knapsackpro.test:3000/v1/queues/queue
D, [2023-12-21T15:31:13.312325 #74247] DEBUG -- : [knapsack_pro] API request UUID: 2fab40e6-fcb6-47e7-9214-98289ceff0ea
D, [2023-12-21T15:31:13.312334 #74247] DEBUG -- : [knapsack_pro] API response:
D, [2023-12-21T15:31:13.312369 #74247] DEBUG -- : [knapsack_pro] {"queue_name"=>"130:8f81841dfd64325d5f6bac73642eda8a", "build_subset_id"=>nil, "test_files"=>[{"path"=>"spec/controllers/welcome_controller_spec.rb[1:1:1]", "time_execution"=>0.00206999992951751}, {"path"=>"spec/rake_tasks/dummy_rake_spec.rb[1:1:2]", "time_execution"=>0.00204199994914234}, {"path"=>"spec/bar_spec.rb[1:1]", "time_execution"=>0.00160199997480959}, {"path"=>"spec/services/meme_spec.rb[1:1:1]", "time_execution"=>0.00156000000424683}, {"path"=>"spec/collection_spec.rb[1:1:1:1]", "time_execution"=>0.00141599995549768}, {"path"=>"spec/services/calculator_spec.rb[1:2:1]", "time_execution"=>0.00101300003007054}, {"path"=>"spec/timecop_spec.rb[1:2]", "time_execution"=>0.000977999996393919}]}
----------Before Subset Queue Hook - run before the subset of the test suite----------
2nd KnapsackPro::Hooks::Queue.before_subset_queue
Run options: include {:ids=>{"./spec/controllers/welcome_controller_spec.rb"=>["1:1:1"], "./spec/rake_tasks/dummy_rake_spec.rb"=>["1:1:2"], "./spec/bar_spec.rb"=>["1:1"], "./spec/services/meme_spec.rb"=>["1:1:1"], "./spec/collection_spec.rb"=>["1:1:1:1"], "./spec/services/calculator_spec.rb"=>["1:2:1"], "./spec/timecop_spec.rb"=>["1:2"]}}
before suite

WelcomeController
before all
  #index
around each start
before each
after each
around each stop
    is expected to be successful
after all

Dummy rake
before all
  dummy:do_something_once
around each start
before each
Count: 1
after each
around each stop
    calls the rake task once again (increases counter by one)
after all

Bar
before all
around each start
before each
after each
around each stop
  is expected to be a kind of Article(id: integer, title: string, body: text, created_at: datetime, updated_at: datetime)
after all

Meme
before all
  #i_can_has_cheezburger?
around each start
before each
after each
around each stop
    is expected to eq "OHAI!"
after all

Array
before all
  behaves like a collection
    initialized with 3 items
around each start
before each
after each
around each stop
      says it has three items
after all

Calculator
before all
  #add
around each start
before each
after each
around each stop
    is expected to eq 5
after all

Timecop
before all
around each start
before each
after each
around each stop
  when stub Time
after all
after suite
D, [2023-12-21T15:31:13.351748 #74247] DEBUG -- : [knapsack_pro] Global time execution for tests: 0.07712200004607439s

I, [2023-12-21T15:31:13.363965 #74247]  INFO -- : [knapsack_pro] To retry the last batch of tests fetched from the API Queue, please run the following command on your machine:
I, [2023-12-21T15:31:13.363987 #74247]  INFO -- : [knapsack_pro] bundle exec rspec --format documentation --format RspecJunitFormatter --out tmp/test-reports/rspec/queue_mode/rspec_1.xml --default-path spec "spec/controllers/welcome_controller_spec.rb[1:1:1]" "spec/rake_tasks/dummy_rake_spec.rb[1:1:2]" "spec/bar_spec.rb[1:1]" "spec/services/meme_spec.rb[1:1:1]" "spec/collection_spec.rb[1:1:1:1]" "spec/services/calculator_spec.rb[1:2:1]" "spec/timecop_spec.rb[1:2]"
----------After Subset Queue Hook - run after the subset of the test suite----------
2nd KnapsackPro::Hooks::Queue.after_subset_queue
D, [2023-12-21T15:31:13.384807 #74247] DEBUG -- : [knapsack_pro] POST http://api.knapsackpro.test:3000/v1/queues/queue
D, [2023-12-21T15:31:13.384827 #74247] DEBUG -- : [knapsack_pro] API request UUID: 3aa6e512-7531-4817-b2ef-5abf1b772ea5
D, [2023-12-21T15:31:13.384836 #74247] DEBUG -- : [knapsack_pro] API response:
D, [2023-12-21T15:31:13.384857 #74247] DEBUG -- : [knapsack_pro] {"queue_name"=>"130:8f81841dfd64325d5f6bac73642eda8a", "build_subset_id"=>nil, "test_files"=>[{"path"=>"spec/collection_spec.rb[4:1:1:1]", "time_execution"=>0.000514000072143972}, {"path"=>"spec/dir with spaces/foobar_spec.rb[1:1]", "time_execution"=>0.000492999912239611}]}
----------Before Subset Queue Hook - run before the subset of the test suite----------
2nd KnapsackPro::Hooks::Queue.before_subset_queue
WARNING: Shared example group 'a collection' has been previously defined at:
  /Users/artur/Documents/github/knapsack-pro/rails-app-with-knapsack_pro/spec/collection_spec.rb:3
...and you are now defining it at:
  /Users/artur/Documents/github/knapsack-pro/rails-app-with-knapsack_pro/spec/collection_spec.rb:3
The new definition will overwrite the original one.
Run options: include {:ids=>{"./spec/collection_spec.rb"=>["4:1:1:1"], "./spec/dir with spaces/foobar_spec.rb"=>["1:1"]}}
before suite

MySet
before all
  it should behave like a collection
    initialized with 3 items
around each start
before each
after each
around each stop
      says it has three items
after all

FooBar
before all
around each start
before each
after each
around each stop
  is expected to equal true
after all
after suite
D, [2023-12-21T15:31:13.425299 #74247] DEBUG -- : [knapsack_pro] Global time execution for tests: 0.07350599998608232s

I, [2023-12-21T15:31:13.440000 #74247]  INFO -- : [knapsack_pro] To retry the last batch of tests fetched from the API Queue, please run the following command on your machine:
I, [2023-12-21T15:31:13.440020 #74247]  INFO -- : [knapsack_pro] bundle exec rspec --format documentation --format RspecJunitFormatter --out tmp/test-reports/rspec/queue_mode/rspec_1.xml --default-path spec "spec/collection_spec.rb[4:1:1:1]" "spec/dir with spaces/foobar_spec.rb[1:1]"
----------After Subset Queue Hook - run after the subset of the test suite----------
2nd KnapsackPro::Hooks::Queue.after_subset_queue
D, [2023-12-21T15:31:13.461427 #74247] DEBUG -- : [knapsack_pro] POST http://api.knapsackpro.test:3000/v1/queues/queue
D, [2023-12-21T15:31:13.461448 #74247] DEBUG -- : [knapsack_pro] API request UUID: d37118d4-d22b-45d1-a919-a1a92f4ce71c
D, [2023-12-21T15:31:13.461456 #74247] DEBUG -- : [knapsack_pro] API response:
D, [2023-12-21T15:31:13.461467 #74247] DEBUG -- : [knapsack_pro] {"queue_name"=>"130:8f81841dfd64325d5f6bac73642eda8a", "build_subset_id"=>nil, "test_files"=>[]}
Knapsack Pro Queue finished!

All pending tests on this CI node:

Pending: (Failures listed here are expected and do not affect your suite's status)

  1) PendingController
     # Temporarily skipped with xit
     # ./spec/controllers/pending_controller_spec.rb:7

  2) Pending
     # Temporarily skipped with xit
     # ./spec/pending_spec.rb:2

  3) PendingController
     # Temporarily skipped with xit
     # ./spec/controllers/dashboard/pending_controller_spec.rb:2

  4) Calculator Page when add two numbers this must fail
     # Temporarily skipped with xit
     # ./spec/features/calculator_spec.rb:30



Finished in 20.03 seconds
25 examples, 0 failures, 4 pending
I, [2023-12-21T15:31:13.461582 #74247]  INFO -- : [knapsack_pro] To retry all the tests assigned to this CI node, please run the following command on your machine:
I, [2023-12-21T15:31:13.461601 #74247]  INFO -- : [knapsack_pro] bundle exec rspec --format documentation --format RspecJunitFormatter --out tmp/test-reports/rspec/queue_mode/rspec_1.xml --default-path spec "spec/controllers/pending_controller_spec.rb[1:1]" "spec/pending_spec.rb[1:1]" "spec/controllers/dashboard/pending_controller_spec.rb[1:1]" "spec/features/calculator_spec.rb[1:2:2]" "spec/slow_shared_examples_spec.rb[1:1:1]" "spec/track_context_time_spec.rb[1:1:1]" "spec/timecop_spec.rb[1:1]" "spec/features/calculator_spec.rb[1:2:1]" "spec/features/calculator_spec.rb[1:1:1]" "spec/async/reactor_spec.rb[1:1]" "spec/controllers/articles_controller_spec.rb[1:1:2]" "spec/controllers/articles_controller_spec.rb[1:1:1]" "spec/vcr_spec.rb[1:1]" "spec/features/homepage_spec.rb[1:2]" "spec/features/homepage_spec.rb[1:1]" "spec/controllers/articles_controller_spec.rb[1:2:1]" "spec/controllers/welcome_controller_spec.rb[1:1:1]" "spec/rake_tasks/dummy_rake_spec.rb[1:1:2]" "spec/bar_spec.rb[1:1]" "spec/services/meme_spec.rb[1:1:1]" "spec/collection_spec.rb[1:1:1:1]" "spec/services/calculator_spec.rb[1:2:1]" "spec/timecop_spec.rb[1:2]" "spec/collection_spec.rb[4:1:1:1]" "spec/dir with spaces/foobar_spec.rb[1:1]"
++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
after suite hook called only once
Run this only when using Knapsack Pro Queue Mode
This code is executed outside of the RSpec after(:suite) hook context because it's impossible to determine which after(:suite) is the last one to execute until it's executed.
----------After Queue Hook - run after test suite----------
2nd KnapsackPro::Hooks::Queue.after_queue
D, [2023-12-21T15:31:13.498815 #74247] DEBUG -- : [knapsack_pro] POST http://api.knapsackpro.test:3000/v1/build_subsets
D, [2023-12-21T15:31:13.498840 #74247] DEBUG -- : [knapsack_pro] API request UUID: 5a0b64ce-a4aa-447b-a7bd-dd1eeaa122f8
D, [2023-12-21T15:31:13.498848 #74247] DEBUG -- : [knapsack_pro] API response:
D, [2023-12-21T15:31:13.498856 #74247] DEBUG -- : [knapsack_pro]
D, [2023-12-21T15:31:13.498867 #74247] DEBUG -- : [knapsack_pro] Saved time execution report on Knapsack Pro API server.
Coverage report generated for RSpec, rspec_ci_node_0, rspec_ci_node_1 to /Users/artur/Documents/github/knapsack-pro/rails-app-with-knapsack_pro/coverage. 347 / 412 LOC (84.22%) covered.
```


# knapsack_pro version based on [Gusto PR](https://github.com/KnapsackPro/knapsack_pro-ruby/pull/226)

**Result:** Not all test cases are executed (32/50 bad, looks like skipped test cases)

```
 ruby bin/collect_junit_xml_reports.rb > tmp/junit_test_cases_summary2.txt && cat tmp/junit_test_cases_summary2.txt
spec.async.reactor_spec, Async::IO should send and receive data within the same reactor
spec.bar_spec, Bar is expected to be a kind of Article(id: integer, title: string, body: text, created_at: datetime, updated_at: datetime)
spec.collection_spec, Array behaves like a collection #include? with an an item that is in the collection returns true
spec.collection_spec, Array behaves like a collection #include? with an an item that is not in the collection returns false
spec.collection_spec, MySet it should behave like a collection #include? with an an item that is in the collection returns true
spec.collection_spec, MySet it should behave like a collection initialized with 3 items says it has three items
spec.controllers.articles_controller_spec, ArticlesController#index is expected to be successful
spec.controllers.dashboard.pending_controller_spec, PendingController
spec.controllers.pending_controller_spec, PendingController
spec.controllers.welcome_controller_spec, WelcomeController#index is expected to be successful
spec.dir with spaces.foobar_spec, FooBar is expected to equal true
spec.features.calculator_spec, Calculator Page when add two numbers this must fail
spec.features.homepage_spec, Homepage Features has link to calculator page
spec.foo_spec, Foo is expected to equal true
spec.options_spec, RSpec Options is expected to eq :automatic
spec.pending_spec, Pending
spec.rake_tasks.dummy_rake_spec, Dummy rake dummy:do_something_once calls the rake task once (increases counter by one)
spec.rake_tasks.dummy_rake_spec, Dummy rake dummy:do_something_once calls the rake task once again (increases counter by one)
spec.retry_spec, Retry should fail always
spec.retry_spec, Retry should randomly succeed
spec.services.calculator_spec, Calculator#add is expected to eq 5
spec.services.meme_spec, Meme#i_can_has_cheezburger? is expected to eq "OHAI!"
spec.services.meme_spec, Meme#will_it_blend? is expected to eq "YES!"
spec.slow_shared_examples_spec, Example of slow shared examples behaves like slow shared example test is expected to equal true
spec.slow_shared_examples_spec, Example of slow shared examples is expected to equal true
spec.system_exit_spec, SystemExit is expected to equal true
spec.time_helpers_spec, Time travel with ActiveSupport::Testing::TimeHelpers travel_back is expected to eq 2004
spec.time_helpers_spec, Time travel with ActiveSupport::Testing::TimeHelpers travel_to block is expected to eq 20
spec.timecop_spec, Timecop travel in time
spec.track_context_time_spec, Track context time when something test 1
spec.track_context_time_spec, Track context time when something test 2
spec.vcr_spec, VCR is expected to include "Example domains"

Test cases: 32
```

## CI node 0

```
➜  rails-app-with-knapsack_pro git:(junit-reports) ✗ bin/knapsack_pro_queue_rspec_record_first_run_junit 0 2 gusto-v9 ci-build-9
D, [2023-12-21T15:36:11.069773 #75390] DEBUG -- : [knapsack_pro] Detected 24 slow test files: [{"path"=>"spec/async/reactor_spec.rb"}, {"path"=>"spec/bar_spec.rb"}, {"path"=>"spec/collection_spec.rb"}, {"path"=>"spec/controllers/articles_controller_spec.rb"}, {"path"=>"spec/controllers/dashboard/pending_controller_spec.rb"}, {"path"=>"spec/controllers/pending_controller_spec.rb"}, {"path"=>"spec/controllers/shared_articles_controller_spec.rb"}, {"path"=>"spec/controllers/welcome_controller_spec.rb"}, {"path"=>"spec/dir with spaces/foobar_spec.rb"}, {"path"=>"spec/features/calculator_spec.rb"}, {"path"=>"spec/features/homepage_spec.rb"}, {"path"=>"spec/foo_spec.rb"}, {"path"=>"spec/options_spec.rb"}, {"path"=>"spec/pending_spec.rb"}, {"path"=>"spec/rake_tasks/dummy_rake_spec.rb"}, {"path"=>"spec/retry_spec.rb"}, {"path"=>"spec/services/calculator_spec.rb"}, {"path"=>"spec/services/meme_spec.rb"}, {"path"=>"spec/slow_shared_examples_spec.rb"}, {"path"=>"spec/system_exit_spec.rb"}, {"path"=>"spec/time_helpers_spec.rb"}, {"path"=>"spec/timecop_spec.rb"}, {"path"=>"spec/track_context_time_spec.rb"}, {"path"=>"spec/vcr_spec.rb"}]
I, [2023-12-21T15:36:11.069955 #75390]  INFO -- : [knapsack_pro] Generating RSpec test examples JSON report for slow test files to prepare it to be split by test examples (by individual test cases). Thanks to that, a single slow test file can be split across parallel CI nodes. Analyzing 24 slow test files.
D, [2023-12-21T15:36:12.507321 #75394] DEBUG -- : [knapsack_pro] Test suite time execution queue recording enabled.
++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
CUSTOM_VARIABLE_FOR_RSPEC_TEST_EXAMPLE_DETECTOR is not set
rspec pid: 75394
Coverage report generated for RSpec, rspec_ci_node_0, rspec_ci_node_1 to /Users/artur/Documents/github/knapsack-pro/rails-app-with-knapsack_pro/coverage. 347 / 412 LOC (84.22%) covered.
I, [2023-12-21T15:36:13.076664 #75390]  INFO -- : [knapsack_pro] Setup RSpec runner.
D, [2023-12-21T15:36:13.132881 #75390] DEBUG -- : [knapsack_pro] Test suite time execution queue recording enabled.
++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
CUSTOM_VARIABLE_FOR_RSPEC_TEST_EXAMPLE_DETECTOR is not set
rspec pid: 75390
++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
RSpec before suite hook called only once
Run this only when using Knapsack Pro Queue Mode
This code is executed within the context of RSpec before(:suite) hook
----------Before Queue Hook - run before test suite----------
2nd KnapsackPro::Hooks::Queue.before_queue
before suite
I, [2023-12-21T15:36:13.643418 #75390]  INFO -- : [knapsack_pro] Fetch test batches from Knapsack Pro API
I, [2023-12-21T15:36:13.643510 #75390]  INFO -- : [knapsack_pro] KNAPSACK_PRO_FIXED_QUEUE_SPLIT is not set. Using default value: true. Learn more at https://knapsackpro.com/perma/ruby/fixed-queue-split
D, [2023-12-21T15:36:13.727808 #75390] DEBUG -- : [knapsack_pro] POST http://api.knapsackpro.test:3000/v1/queues/queue
D, [2023-12-21T15:36:13.727832 #75390] DEBUG -- : [knapsack_pro] API request UUID: f157dc65-f66a-44de-ab86-553e03cd928c
D, [2023-12-21T15:36:13.727843 #75390] DEBUG -- : [knapsack_pro] API response:
D, [2023-12-21T15:36:13.727860 #75390] DEBUG -- : [knapsack_pro] {"queue_name"=>"130:4165d4447542f8df3d0017898d02c9c8:queue-must-be-initialized-first", "message"=>"A queue with a list of test files does not exist on the API side yet. If you see this message, everything works as expected. Now Knapsack Pro client will initialize a queue on the API side with a list of test files you want to run. The request to initialize the queue will have attributes like can_initialize_queue=true, attempt_connect_to_queue=false, and test_files, etc.", "code"=>"ATTEMPT_CONNECT_TO_QUEUE_FAILED"}
D, [2023-12-21T15:36:13.794988 #75390] DEBUG -- : [knapsack_pro] POST http://api.knapsackpro.test:3000/v1/queues/queue
D, [2023-12-21T15:36:13.795009 #75390] DEBUG -- : [knapsack_pro] API request UUID: c4044f20-7dab-4146-991e-4c9b4fb7821d
D, [2023-12-21T15:36:13.795020 #75390] DEBUG -- : [knapsack_pro] API response:
D, [2023-12-21T15:36:13.795043 #75390] DEBUG -- : [knapsack_pro] {"queue_name"=>"130:4165d4447542f8df3d0017898d02c9c8", "build_subset_id"=>nil, "test_files"=>[{"path"=>"spec/controllers/shared.rb[1:1:1:1:1]", "time_execution"=>0.0}]}
I, [2023-12-21T15:36:13.795122 #75390]  INFO -- : [knapsack_pro] Wrap tests in before/after subqueue hooks
----------Before Subset Queue Hook - run before the subset of the test suite----------
2nd KnapsackPro::Hooks::Queue.before_subset_queue
I, [2023-12-21T15:36:13.795835 #75390]  INFO -- : [knapsack_pro] To retry the last batch of tests fetched from the API Queue, please run the following command on your machine:
I, [2023-12-21T15:36:13.795861 #75390]  INFO -- : [knapsack_pro] bundle exec rspec --format documentation --format RspecJunitFormatter --out tmp/test-reports/rspec/queue_mode/rspec_0.xml --default-path spec "spec/controllers/shared.rb[1:1:1:1:1]"
----------After Subset Queue Hook - run after the subset of the test suite----------
2nd KnapsackPro::Hooks::Queue.after_subset_queue
D, [2023-12-21T15:36:13.821473 #75390] DEBUG -- : [knapsack_pro] POST http://api.knapsackpro.test:3000/v1/queues/queue
D, [2023-12-21T15:36:13.821499 #75390] DEBUG -- : [knapsack_pro] API request UUID: 2754156d-af41-4e01-946f-f8c16a4d32f7
D, [2023-12-21T15:36:13.821510 #75390] DEBUG -- : [knapsack_pro] API response:
D, [2023-12-21T15:36:13.821527 #75390] DEBUG -- : [knapsack_pro] {"queue_name"=>"130:4165d4447542f8df3d0017898d02c9c8", "build_subset_id"=>nil, "test_files"=>[{"path"=>"spec/features/calculator_spec.rb[1:2:2]", "time_execution"=>0.0}]}
I, [2023-12-21T15:36:13.821544 #75390]  INFO -- : [knapsack_pro] Wrap tests in before/after subqueue hooks
----------Before Subset Queue Hook - run before the subset of the test suite----------
2nd KnapsackPro::Hooks::Queue.before_subset_queue

Calculator Page
before all
  when add two numbers
    this must fail (PENDING: Temporarily skipped with xit)
after all
I, [2023-12-21T15:36:13.825705 #75390]  INFO -- : [knapsack_pro] To retry the last batch of tests fetched from the API Queue, please run the following command on your machine:
I, [2023-12-21T15:36:13.825722 #75390]  INFO -- : [knapsack_pro] bundle exec rspec --format documentation --format RspecJunitFormatter --out tmp/test-reports/rspec/queue_mode/rspec_0.xml --default-path spec "spec/features/calculator_spec.rb[1:2:2]"
----------After Subset Queue Hook - run after the subset of the test suite----------
2nd KnapsackPro::Hooks::Queue.after_subset_queue
D, [2023-12-21T15:36:13.859690 #75390] DEBUG -- : [knapsack_pro] POST http://api.knapsackpro.test:3000/v1/queues/queue
D, [2023-12-21T15:36:13.859710 #75390] DEBUG -- : [knapsack_pro] API request UUID: 990998fe-1f3e-4e0f-a3af-b8a430579b50
D, [2023-12-21T15:36:13.859719 #75390] DEBUG -- : [knapsack_pro] API response:
D, [2023-12-21T15:36:13.859733 #75390] DEBUG -- : [knapsack_pro] {"queue_name"=>"130:4165d4447542f8df3d0017898d02c9c8", "build_subset_id"=>nil, "test_files"=>[{"path"=>"spec/pending_spec.rb[1:1]", "time_execution"=>0.0}]}
I, [2023-12-21T15:36:13.859749 #75390]  INFO -- : [knapsack_pro] Wrap tests in before/after subqueue hooks
----------Before Subset Queue Hook - run before the subset of the test suite----------
2nd KnapsackPro::Hooks::Queue.before_subset_queue

Pending
before all
  example at ./spec/pending_spec.rb:2 (PENDING: Temporarily skipped with xit)
after all
I, [2023-12-21T15:36:13.861187 #75390]  INFO -- : [knapsack_pro] To retry the last batch of tests fetched from the API Queue, please run the following command on your machine:
I, [2023-12-21T15:36:13.861201 #75390]  INFO -- : [knapsack_pro] bundle exec rspec --format documentation --format RspecJunitFormatter --out tmp/test-reports/rspec/queue_mode/rspec_0.xml --default-path spec "spec/pending_spec.rb[1:1]"
----------After Subset Queue Hook - run after the subset of the test suite----------
2nd KnapsackPro::Hooks::Queue.after_subset_queue
D, [2023-12-21T15:36:13.884778 #75390] DEBUG -- : [knapsack_pro] POST http://api.knapsackpro.test:3000/v1/queues/queue
D, [2023-12-21T15:36:13.884799 #75390] DEBUG -- : [knapsack_pro] API request UUID: af0145b8-5eb5-41da-a68b-4e90bedea268
D, [2023-12-21T15:36:13.884811 #75390] DEBUG -- : [knapsack_pro] API response:
D, [2023-12-21T15:36:13.884825 #75390] DEBUG -- : [knapsack_pro] {"queue_name"=>"130:4165d4447542f8df3d0017898d02c9c8", "build_subset_id"=>nil, "test_files"=>[{"path"=>"spec/controllers/dashboard/pending_controller_spec.rb[1:1]", "time_execution"=>0.0}]}
I, [2023-12-21T15:36:13.884846 #75390]  INFO -- : [knapsack_pro] Wrap tests in before/after subqueue hooks
----------Before Subset Queue Hook - run before the subset of the test suite----------
2nd KnapsackPro::Hooks::Queue.before_subset_queue

PendingController
before all
  example at ./spec/controllers/dashboard/pending_controller_spec.rb:2 (PENDING: Temporarily skipped with xit)
after all
I, [2023-12-21T15:36:13.887763 #75390]  INFO -- : [knapsack_pro] To retry the last batch of tests fetched from the API Queue, please run the following command on your machine:
I, [2023-12-21T15:36:13.887800 #75390]  INFO -- : [knapsack_pro] bundle exec rspec --format documentation --format RspecJunitFormatter --out tmp/test-reports/rspec/queue_mode/rspec_0.xml --default-path spec "spec/controllers/dashboard/pending_controller_spec.rb[1:1]"
----------After Subset Queue Hook - run after the subset of the test suite----------
2nd KnapsackPro::Hooks::Queue.after_subset_queue
D, [2023-12-21T15:36:13.910575 #75390] DEBUG -- : [knapsack_pro] POST http://api.knapsackpro.test:3000/v1/queues/queue
D, [2023-12-21T15:36:13.910594 #75390] DEBUG -- : [knapsack_pro] API request UUID: dadb76e5-60db-4090-9620-d853c269685f
D, [2023-12-21T15:36:13.910602 #75390] DEBUG -- : [knapsack_pro] API response:
D, [2023-12-21T15:36:13.910616 #75390] DEBUG -- : [knapsack_pro] {"queue_name"=>"130:4165d4447542f8df3d0017898d02c9c8", "build_subset_id"=>nil, "test_files"=>[{"path"=>"spec/controllers/pending_controller_spec.rb[1:1]", "time_execution"=>0.0}]}
I, [2023-12-21T15:36:13.910631 #75390]  INFO -- : [knapsack_pro] Wrap tests in before/after subqueue hooks
----------Before Subset Queue Hook - run before the subset of the test suite----------
2nd KnapsackPro::Hooks::Queue.before_subset_queue

PendingController
before all
  example at ./spec/controllers/pending_controller_spec.rb:7 (PENDING: Temporarily skipped with xit)
after all
I, [2023-12-21T15:36:13.912068 #75390]  INFO -- : [knapsack_pro] To retry the last batch of tests fetched from the API Queue, please run the following command on your machine:
I, [2023-12-21T15:36:13.912087 #75390]  INFO -- : [knapsack_pro] bundle exec rspec --format documentation --format RspecJunitFormatter --out tmp/test-reports/rspec/queue_mode/rspec_0.xml --default-path spec "spec/controllers/pending_controller_spec.rb[1:1]"
----------After Subset Queue Hook - run after the subset of the test suite----------
2nd KnapsackPro::Hooks::Queue.after_subset_queue
D, [2023-12-21T15:36:13.937836 #75390] DEBUG -- : [knapsack_pro] POST http://api.knapsackpro.test:3000/v1/queues/queue
D, [2023-12-21T15:36:13.937863 #75390] DEBUG -- : [knapsack_pro] API request UUID: 48682d81-e874-4850-bceb-1b12476d2021
D, [2023-12-21T15:36:13.937871 #75390] DEBUG -- : [knapsack_pro] API response:
D, [2023-12-21T15:36:13.937887 #75390] DEBUG -- : [knapsack_pro] {"queue_name"=>"130:4165d4447542f8df3d0017898d02c9c8", "build_subset_id"=>nil, "test_files"=>[{"path"=>"spec/retry_spec.rb[1:2]", "time_execution"=>0.0}]}
I, [2023-12-21T15:36:13.937904 #75390]  INFO -- : [knapsack_pro] Wrap tests in before/after subqueue hooks
----------Before Subset Queue Hook - run before the subset of the test suite----------
2nd KnapsackPro::Hooks::Queue.before_subset_queue

Retry
before all
  should fail always (PENDING: Temporarily skipped with xit)
after all
I, [2023-12-21T15:36:13.939387 #75390]  INFO -- : [knapsack_pro] To retry the last batch of tests fetched from the API Queue, please run the following command on your machine:
I, [2023-12-21T15:36:13.939401 #75390]  INFO -- : [knapsack_pro] bundle exec rspec --format documentation --format RspecJunitFormatter --out tmp/test-reports/rspec/queue_mode/rspec_0.xml --default-path spec "spec/retry_spec.rb[1:2]"
----------After Subset Queue Hook - run after the subset of the test suite----------
2nd KnapsackPro::Hooks::Queue.after_subset_queue
D, [2023-12-21T15:36:13.965241 #75390] DEBUG -- : [knapsack_pro] POST http://api.knapsackpro.test:3000/v1/queues/queue
D, [2023-12-21T15:36:13.965267 #75390] DEBUG -- : [knapsack_pro] API request UUID: 6b4b95b2-caaa-457a-bd66-b1e2c4d1b82f
D, [2023-12-21T15:36:13.965275 #75390] DEBUG -- : [knapsack_pro] API response:
D, [2023-12-21T15:36:13.965292 #75390] DEBUG -- : [knapsack_pro] {"queue_name"=>"130:4165d4447542f8df3d0017898d02c9c8", "build_subset_id"=>nil, "test_files"=>[{"path"=>"spec/slow_shared_examples_spec.rb[1:1:1]", "time_execution"=>12.5385069999611}]}
I, [2023-12-21T15:36:13.965315 #75390]  INFO -- : [knapsack_pro] Wrap tests in before/after subqueue hooks
----------Before Subset Queue Hook - run before the subset of the test suite----------
2nd KnapsackPro::Hooks::Queue.before_subset_queue

Example of slow shared examples
before all
  behaves like slow shared example test
around each start
before each
after each
around each stop
    is expected to equal true
after all
I, [2023-12-21T15:36:26.513331 #75390]  INFO -- : [knapsack_pro] To retry the last batch of tests fetched from the API Queue, please run the following command on your machine:
I, [2023-12-21T15:36:26.513370 #75390]  INFO -- : [knapsack_pro] bundle exec rspec --format documentation --format RspecJunitFormatter --out tmp/test-reports/rspec/queue_mode/rspec_0.xml --default-path spec "spec/slow_shared_examples_spec.rb[1:1:1]"
----------After Subset Queue Hook - run after the subset of the test suite----------
2nd KnapsackPro::Hooks::Queue.after_subset_queue
D, [2023-12-21T15:36:26.542137 #75390] DEBUG -- : [knapsack_pro] POST http://api.knapsackpro.test:3000/v1/queues/queue
D, [2023-12-21T15:36:26.542173 #75390] DEBUG -- : [knapsack_pro] API request UUID: 531d7049-bbfb-43c3-8f83-7aa880ab068c
D, [2023-12-21T15:36:26.542185 #75390] DEBUG -- : [knapsack_pro] API response:
D, [2023-12-21T15:36:26.542213 #75390] DEBUG -- : [knapsack_pro] {"queue_name"=>"130:4165d4447542f8df3d0017898d02c9c8", "build_subset_id"=>nil, "test_files"=>[{"path"=>"spec/track_context_time_spec.rb[1:1:1]", "time_execution"=>5.31584900000598}]}
I, [2023-12-21T15:36:26.542242 #75390]  INFO -- : [knapsack_pro] Wrap tests in before/after subqueue hooks
----------Before Subset Queue Hook - run before the subset of the test suite----------
2nd KnapsackPro::Hooks::Queue.before_subset_queue

Track context time
before all
  when something
around each start
before each
after each
around each stop
    test 1
after all
I, [2023-12-21T15:36:31.869001 #75390]  INFO -- : [knapsack_pro] To retry the last batch of tests fetched from the API Queue, please run the following command on your machine:
I, [2023-12-21T15:36:31.869260 #75390]  INFO -- : [knapsack_pro] bundle exec rspec --format documentation --format RspecJunitFormatter --out tmp/test-reports/rspec/queue_mode/rspec_0.xml --default-path spec "spec/track_context_time_spec.rb[1:1:1]"
----------After Subset Queue Hook - run after the subset of the test suite----------
2nd KnapsackPro::Hooks::Queue.after_subset_queue
D, [2023-12-21T15:36:31.923690 #75390] DEBUG -- : [knapsack_pro] POST http://api.knapsackpro.test:3000/v1/queues/queue
D, [2023-12-21T15:36:31.923725 #75390] DEBUG -- : [knapsack_pro] API request UUID: 512fde10-e16b-41d9-9303-a94ab3837cfd
D, [2023-12-21T15:36:31.923741 #75390] DEBUG -- : [knapsack_pro] API response:
D, [2023-12-21T15:36:31.923771 #75390] DEBUG -- : [knapsack_pro] {"queue_name"=>"130:4165d4447542f8df3d0017898d02c9c8", "build_subset_id"=>nil, "test_files"=>[{"path"=>"spec/time_helpers_spec.rb[1:2:1]", "time_execution"=>1.01308400009293}]}
I, [2023-12-21T15:36:31.923798 #75390]  INFO -- : [knapsack_pro] Wrap tests in before/after subqueue hooks
----------Before Subset Queue Hook - run before the subset of the test suite----------
2nd KnapsackPro::Hooks::Queue.before_subset_queue

Time travel with ActiveSupport::Testing::TimeHelpers
before all
  travel_to block
around each start
before each
after each
around each stop
    is expected to eq 20
after all
I, [2023-12-21T15:36:32.946482 #75390]  INFO -- : [knapsack_pro] To retry the last batch of tests fetched from the API Queue, please run the following command on your machine:
I, [2023-12-21T15:36:32.946744 #75390]  INFO -- : [knapsack_pro] bundle exec rspec --format documentation --format RspecJunitFormatter --out tmp/test-reports/rspec/queue_mode/rspec_0.xml --default-path spec "spec/time_helpers_spec.rb[1:2:1]"
----------After Subset Queue Hook - run after the subset of the test suite----------
2nd KnapsackPro::Hooks::Queue.after_subset_queue
D, [2023-12-21T15:36:33.004089 #75390] DEBUG -- : [knapsack_pro] POST http://api.knapsackpro.test:3000/v1/queues/queue
D, [2023-12-21T15:36:33.004129 #75390] DEBUG -- : [knapsack_pro] API request UUID: 882256a8-c12b-461c-ac6e-6615c4f14765
D, [2023-12-21T15:36:33.004142 #75390] DEBUG -- : [knapsack_pro] API response:
D, [2023-12-21T15:36:33.004186 #75390] DEBUG -- : [knapsack_pro] {"queue_name"=>"130:4165d4447542f8df3d0017898d02c9c8", "build_subset_id"=>nil, "test_files"=>[{"path"=>"spec/time_helpers_spec.rb[1:3:1]", "time_execution"=>1.00219400005881}]}
I, [2023-12-21T15:36:33.004250 #75390]  INFO -- : [knapsack_pro] Wrap tests in before/after subqueue hooks
----------Before Subset Queue Hook - run before the subset of the test suite----------
2nd KnapsackPro::Hooks::Queue.before_subset_queue
I, [2023-12-21T15:36:33.007619 #75390]  INFO -- : [knapsack_pro] To retry the last batch of tests fetched from the API Queue, please run the following command on your machine:
I, [2023-12-21T15:36:33.007660 #75390]  INFO -- : [knapsack_pro] bundle exec rspec --format documentation --format RspecJunitFormatter --out tmp/test-reports/rspec/queue_mode/rspec_0.xml --default-path spec "spec/time_helpers_spec.rb[1:3:1]"
----------After Subset Queue Hook - run after the subset of the test suite----------
2nd KnapsackPro::Hooks::Queue.after_subset_queue
D, [2023-12-21T15:36:33.036900 #75390] DEBUG -- : [knapsack_pro] POST http://api.knapsackpro.test:3000/v1/queues/queue
D, [2023-12-21T15:36:33.036930 #75390] DEBUG -- : [knapsack_pro] API request UUID: 7e2f7fe3-f5e5-4b91-8f45-2ce8fc3fd836
D, [2023-12-21T15:36:33.036943 #75390] DEBUG -- : [knapsack_pro] API response:
D, [2023-12-21T15:36:33.036967 #75390] DEBUG -- : [knapsack_pro] {"queue_name"=>"130:4165d4447542f8df3d0017898d02c9c8", "build_subset_id"=>nil, "test_files"=>[{"path"=>"spec/features/calculator_spec.rb[1:2:1]", "time_execution"=>0.103667999967001}]}
I, [2023-12-21T15:36:33.036992 #75390]  INFO -- : [knapsack_pro] Wrap tests in before/after subqueue hooks
----------Before Subset Queue Hook - run before the subset of the test suite----------
2nd KnapsackPro::Hooks::Queue.before_subset_queue
I, [2023-12-21T15:36:33.039225 #75390]  INFO -- : [knapsack_pro] To retry the last batch of tests fetched from the API Queue, please run the following command on your machine:
I, [2023-12-21T15:36:33.039250 #75390]  INFO -- : [knapsack_pro] bundle exec rspec --format documentation --format RspecJunitFormatter --out tmp/test-reports/rspec/queue_mode/rspec_0.xml --default-path spec "spec/features/calculator_spec.rb[1:2:1]"
----------After Subset Queue Hook - run after the subset of the test suite----------
2nd KnapsackPro::Hooks::Queue.after_subset_queue
D, [2023-12-21T15:36:33.063376 #75390] DEBUG -- : [knapsack_pro] POST http://api.knapsackpro.test:3000/v1/queues/queue
D, [2023-12-21T15:36:33.063393 #75390] DEBUG -- : [knapsack_pro] API request UUID: 5e8c5a54-2fc8-433b-90a9-a4a22d01ba01
D, [2023-12-21T15:36:33.063402 #75390] DEBUG -- : [knapsack_pro] API response:
D, [2023-12-21T15:36:33.063463 #75390] DEBUG -- : [knapsack_pro] {"queue_name"=>"130:4165d4447542f8df3d0017898d02c9c8", "build_subset_id"=>nil, "test_files"=>[{"path"=>"spec/async/reactor_spec.rb[1:1]", "time_execution"=>0.0730150000890717}]}
I, [2023-12-21T15:36:33.063479 #75390]  INFO -- : [knapsack_pro] Wrap tests in before/after subqueue hooks
----------Before Subset Queue Hook - run before the subset of the test suite----------
2nd KnapsackPro::Hooks::Queue.before_subset_queue

Async::IO
before all
around each start
before each
after each
around each stop
  should send and receive data within the same reactor
after all
I, [2023-12-21T15:36:33.119899 #75390]  INFO -- : [knapsack_pro] To retry the last batch of tests fetched from the API Queue, please run the following command on your machine:
I, [2023-12-21T15:36:33.119925 #75390]  INFO -- : [knapsack_pro] bundle exec rspec --format documentation --format RspecJunitFormatter --out tmp/test-reports/rspec/queue_mode/rspec_0.xml --default-path spec "spec/async/reactor_spec.rb[1:1]"
----------After Subset Queue Hook - run after the subset of the test suite----------
2nd KnapsackPro::Hooks::Queue.after_subset_queue
D, [2023-12-21T15:36:33.140383 #75390] DEBUG -- : [knapsack_pro] POST http://api.knapsackpro.test:3000/v1/queues/queue
D, [2023-12-21T15:36:33.140397 #75390] DEBUG -- : [knapsack_pro] API request UUID: da82da65-5993-4c01-891a-83312a6c8999
D, [2023-12-21T15:36:33.140405 #75390] DEBUG -- : [knapsack_pro] API response:
D, [2023-12-21T15:36:33.140425 #75390] DEBUG -- : [knapsack_pro] {"queue_name"=>"130:4165d4447542f8df3d0017898d02c9c8", "build_subset_id"=>nil, "test_files"=>[{"path"=>"spec/features/calculator_spec.rb[1:1:1]", "time_execution"=>0.0201270000543445}, {"path"=>"spec/controllers/articles_controller_spec.rb[1:1:2]", "time_execution"=>0.0173580000409856}]}
I, [2023-12-21T15:36:33.140439 #75390]  INFO -- : [knapsack_pro] Wrap tests in before/after subqueue hooks
----------Before Subset Queue Hook - run before the subset of the test suite----------
2nd KnapsackPro::Hooks::Queue.before_subset_queue

ArticlesController
before all
  #index
around each start
before each
after each
around each stop
    is expected to be successful
after all
I, [2023-12-21T15:36:33.167445 #75390]  INFO -- : [knapsack_pro] To retry the last batch of tests fetched from the API Queue, please run the following command on your machine:
I, [2023-12-21T15:36:33.167465 #75390]  INFO -- : [knapsack_pro] bundle exec rspec --format documentation --format RspecJunitFormatter --out tmp/test-reports/rspec/queue_mode/rspec_0.xml --default-path spec "spec/features/calculator_spec.rb[1:1:1]" "spec/controllers/articles_controller_spec.rb[1:1:2]"
----------After Subset Queue Hook - run after the subset of the test suite----------
2nd KnapsackPro::Hooks::Queue.after_subset_queue
D, [2023-12-21T15:36:33.186290 #75390] DEBUG -- : [knapsack_pro] POST http://api.knapsackpro.test:3000/v1/queues/queue
D, [2023-12-21T15:36:33.186304 #75390] DEBUG -- : [knapsack_pro] API request UUID: 04f497f3-6bf4-4a6e-ac05-86f789febb47
D, [2023-12-21T15:36:33.186312 #75390] DEBUG -- : [knapsack_pro] API response:
D, [2023-12-21T15:36:33.186326 #75390] DEBUG -- : [knapsack_pro] {"queue_name"=>"130:4165d4447542f8df3d0017898d02c9c8", "build_subset_id"=>nil, "test_files"=>[{"path"=>"spec/vcr_spec.rb[1:1]", "time_execution"=>0.0171789999585599}]}
I, [2023-12-21T15:36:33.186339 #75390]  INFO -- : [knapsack_pro] Wrap tests in before/after subqueue hooks
----------Before Subset Queue Hook - run before the subset of the test suite----------
2nd KnapsackPro::Hooks::Queue.before_subset_queue

VCR
before all
around each start
before each
after each
around each stop
  is expected to include "Example domains"
after all
I, [2023-12-21T15:36:33.191301 #75390]  INFO -- : [knapsack_pro] To retry the last batch of tests fetched from the API Queue, please run the following command on your machine:
I, [2023-12-21T15:36:33.191319 #75390]  INFO -- : [knapsack_pro] bundle exec rspec --format documentation --format RspecJunitFormatter --out tmp/test-reports/rspec/queue_mode/rspec_0.xml --default-path spec "spec/vcr_spec.rb[1:1]"
----------After Subset Queue Hook - run after the subset of the test suite----------
2nd KnapsackPro::Hooks::Queue.after_subset_queue
D, [2023-12-21T15:36:33.222515 #75390] DEBUG -- : [knapsack_pro] POST http://api.knapsackpro.test:3000/v1/queues/queue
D, [2023-12-21T15:36:33.222532 #75390] DEBUG -- : [knapsack_pro] API request UUID: 655e1ab6-da9a-4690-b724-ba933702d35b
D, [2023-12-21T15:36:33.222541 #75390] DEBUG -- : [knapsack_pro] API response:
D, [2023-12-21T15:36:33.222556 #75390] DEBUG -- : [knapsack_pro] {"queue_name"=>"130:4165d4447542f8df3d0017898d02c9c8", "build_subset_id"=>nil, "test_files"=>[{"path"=>"spec/features/homepage_spec.rb[1:2]", "time_execution"=>0.0146040000254288}]}
I, [2023-12-21T15:36:33.222571 #75390]  INFO -- : [knapsack_pro] Wrap tests in before/after subqueue hooks
----------Before Subset Queue Hook - run before the subset of the test suite----------
2nd KnapsackPro::Hooks::Queue.before_subset_queue

Homepage Features
before all
around each start
before each
after each
around each stop
  has link to calculator page
after all
I, [2023-12-21T15:36:33.298364 #75390]  INFO -- : [knapsack_pro] To retry the last batch of tests fetched from the API Queue, please run the following command on your machine:
I, [2023-12-21T15:36:33.298388 #75390]  INFO -- : [knapsack_pro] bundle exec rspec --format documentation --format RspecJunitFormatter --out tmp/test-reports/rspec/queue_mode/rspec_0.xml --default-path spec "spec/features/homepage_spec.rb[1:2]"
----------After Subset Queue Hook - run after the subset of the test suite----------
2nd KnapsackPro::Hooks::Queue.after_subset_queue
D, [2023-12-21T15:36:33.319961 #75390] DEBUG -- : [knapsack_pro] POST http://api.knapsackpro.test:3000/v1/queues/queue
D, [2023-12-21T15:36:33.319977 #75390] DEBUG -- : [knapsack_pro] API request UUID: 63dcae53-8c6d-44b1-9e54-349f8d024ae8
D, [2023-12-21T15:36:33.319986 #75390] DEBUG -- : [knapsack_pro] API response:
D, [2023-12-21T15:36:33.320005 #75390] DEBUG -- : [knapsack_pro] {"queue_name"=>"130:4165d4447542f8df3d0017898d02c9c8", "build_subset_id"=>nil, "test_files"=>[{"path"=>"spec/features/homepage_spec.rb[1:1]", "time_execution"=>0.00712900003418326}, {"path"=>"spec/controllers/articles_controller_spec.rb[1:1:1]", "time_execution"=>0.00480699993204325}]}
I, [2023-12-21T15:36:33.320021 #75390]  INFO -- : [knapsack_pro] Wrap tests in before/after subqueue hooks
----------Before Subset Queue Hook - run before the subset of the test suite----------
2nd KnapsackPro::Hooks::Queue.before_subset_queue
I, [2023-12-21T15:36:33.322684 #75390]  INFO -- : [knapsack_pro] To retry the last batch of tests fetched from the API Queue, please run the following command on your machine:
I, [2023-12-21T15:36:33.322703 #75390]  INFO -- : [knapsack_pro] bundle exec rspec --format documentation --format RspecJunitFormatter --out tmp/test-reports/rspec/queue_mode/rspec_0.xml --default-path spec "spec/features/homepage_spec.rb[1:1]" "spec/controllers/articles_controller_spec.rb[1:1:1]"
----------After Subset Queue Hook - run after the subset of the test suite----------
2nd KnapsackPro::Hooks::Queue.after_subset_queue
D, [2023-12-21T15:36:33.388403 #75390] DEBUG -- : [knapsack_pro] POST http://api.knapsackpro.test:3000/v1/queues/queue
D, [2023-12-21T15:36:33.388423 #75390] DEBUG -- : [knapsack_pro] API request UUID: 5a227fae-5ed8-4ca8-8397-2975979c722b
D, [2023-12-21T15:36:33.388433 #75390] DEBUG -- : [knapsack_pro] API response:
D, [2023-12-21T15:36:33.388462 #75390] DEBUG -- : [knapsack_pro] {"queue_name"=>"130:4165d4447542f8df3d0017898d02c9c8", "build_subset_id"=>nil, "test_files"=>[{"path"=>"spec/services/calculator_spec.rb[1:2:1]", "time_execution"=>0.0030900000128895}, {"path"=>"spec/collection_spec.rb[1:1:2:1:1]", "time_execution"=>0.0024210000410676}, {"path"=>"spec/controllers/articles_controller_spec.rb[1:2:1]", "time_execution"=>0.00223500002175569}, {"path"=>"spec/rake_tasks/dummy_rake_spec.rb[1:1:2]", "time_execution"=>0.00210599997080862}, {"path"=>"spec/controllers/welcome_controller_spec.rb[1:1:1]", "time_execution"=>0.00205099990125745}]}
I, [2023-12-21T15:36:33.388481 #75390]  INFO -- : [knapsack_pro] Wrap tests in before/after subqueue hooks
----------Before Subset Queue Hook - run before the subset of the test suite----------
2nd KnapsackPro::Hooks::Queue.before_subset_queue

Calculator
before all
  #add
around each start
before each
after each
around each stop
    is expected to eq 5
after all

Array
before all
  behaves like a collection
    #include?
      with an an item that is in the collection
around each start
before each
after each
around each stop
        returns true
after all

Dummy rake
before all
  dummy:do_something_once
around each start
before each
Count: 1
after each
around each stop
    calls the rake task once again (increases counter by one)
after all

WelcomeController
before all
  #index
around each start
before each
after each
around each stop
    is expected to be successful
after all
I, [2023-12-21T15:36:33.406090 #75390]  INFO -- : [knapsack_pro] To retry the last batch of tests fetched from the API Queue, please run the following command on your machine:
I, [2023-12-21T15:36:33.406112 #75390]  INFO -- : [knapsack_pro] bundle exec rspec --format documentation --format RspecJunitFormatter --out tmp/test-reports/rspec/queue_mode/rspec_0.xml --default-path spec "spec/services/calculator_spec.rb[1:2:1]" "spec/collection_spec.rb[1:1:2:1:1]" "spec/controllers/articles_controller_spec.rb[1:2:1]" "spec/rake_tasks/dummy_rake_spec.rb[1:1:2]" "spec/controllers/welcome_controller_spec.rb[1:1:1]"
----------After Subset Queue Hook - run after the subset of the test suite----------
2nd KnapsackPro::Hooks::Queue.after_subset_queue
D, [2023-12-21T15:36:33.446122 #75390] DEBUG -- : [knapsack_pro] POST http://api.knapsackpro.test:3000/v1/queues/queue
D, [2023-12-21T15:36:33.446153 #75390] DEBUG -- : [knapsack_pro] API request UUID: 28796c31-4889-423d-ace7-2a52e7274c06
D, [2023-12-21T15:36:33.446164 #75390] DEBUG -- : [knapsack_pro] API response:
D, [2023-12-21T15:36:33.446217 #75390] DEBUG -- : [knapsack_pro] {"queue_name"=>"130:4165d4447542f8df3d0017898d02c9c8", "build_subset_id"=>nil, "test_files"=>[{"path"=>"spec/collection_spec.rb[2:1:2:2:1]", "time_execution"=>0.000660000019706786}, {"path"=>"spec/collection_spec.rb[1:1:1:1]", "time_execution"=>0.000576999969780445}, {"path"=>"spec/collection_spec.rb[4:1:2:2:1]", "time_execution"=>0.000574999954551458}, {"path"=>"spec/collection_spec.rb[2:1:1:1]", "time_execution"=>0.000515000079758465}, {"path"=>"spec/services/calculator_spec.rb[1:3:1]", "time_execution"=>0.000503999995999038}, {"path"=>"spec/services/calculator_spec.rb[1:1:2:1]", "time_execution"=>0.000499999965541065}, {"path"=>"spec/services/calculator_spec.rb[1:1:1:1]", "time_execution"=>0.000496999942697585}, {"path"=>"spec/collection_spec.rb[3:2:2:1]", "time_execution"=>0.000476999906823039}, {"path"=>"spec/collection_spec.rb[2:1:2:1:1]", "time_execution"=>0.000467000063508749}, {"path"=>"spec/system_exit_spec.rb[1:1]", "time_execution"=>0.000428000115789473}, {"path"=>"spec/collection_spec.rb[3:1:1]", "time_execution"=>0.000427999999374151}, {"path"=>"spec/collection_spec.rb[3:2:1:1]", "time_execution"=>0.000411999877542257}, {"path"=>"spec/services/meme_spec.rb[1:2:1]", "time_execution"=>0.00039399997331202}, {"path"=>"spec/options_spec.rb[1:1]", "time_execution"=>0.000342000043019652}]}
I, [2023-12-21T15:36:33.446315 #75390]  INFO -- : [knapsack_pro] Wrap tests in before/after subqueue hooks
----------Before Subset Queue Hook - run before the subset of the test suite----------
2nd KnapsackPro::Hooks::Queue.before_subset_queue
WARNING: Shared example group 'a collection' has been previously defined at:
  /Users/artur/Documents/github/knapsack-pro/rails-app-with-knapsack_pro/spec/collection_spec.rb:3
...and you are now defining it at:
  /Users/artur/Documents/github/knapsack-pro/rails-app-with-knapsack_pro/spec/collection_spec.rb:3
The new definition will overwrite the original one.

SystemExit
before all
around each start
before each
after each
around each stop
  is expected to equal true
after all

Meme
before all
  #will_it_blend?
around each start
before each
after each
around each stop
    is expected to eq "YES!"
after all

RSpec Options
before all
around each start
before each
after each
around each stop
  is expected to eq :automatic
after all
I, [2023-12-21T15:36:33.458459 #75390]  INFO -- : [knapsack_pro] To retry the last batch of tests fetched from the API Queue, please run the following command on your machine:
I, [2023-12-21T15:36:33.458494 #75390]  INFO -- : [knapsack_pro] bundle exec rspec --format documentation --format RspecJunitFormatter --out tmp/test-reports/rspec/queue_mode/rspec_0.xml --default-path spec "spec/collection_spec.rb[2:1:2:2:1]" "spec/collection_spec.rb[1:1:1:1]" "spec/collection_spec.rb[4:1:2:2:1]" "spec/collection_spec.rb[2:1:1:1]" "spec/services/calculator_spec.rb[1:3:1]" "spec/services/calculator_spec.rb[1:1:2:1]" "spec/services/calculator_spec.rb[1:1:1:1]" "spec/collection_spec.rb[3:2:2:1]" "spec/collection_spec.rb[2:1:2:1:1]" "spec/system_exit_spec.rb[1:1]" "spec/collection_spec.rb[3:1:1]" "spec/collection_spec.rb[3:2:1:1]" "spec/services/meme_spec.rb[1:2:1]" "spec/options_spec.rb[1:1]"
----------After Subset Queue Hook - run after the subset of the test suite----------
2nd KnapsackPro::Hooks::Queue.after_subset_queue
D, [2023-12-21T15:36:33.478549 #75390] DEBUG -- : [knapsack_pro] POST http://api.knapsackpro.test:3000/v1/queues/queue
D, [2023-12-21T15:36:33.478583 #75390] DEBUG -- : [knapsack_pro] API request UUID: ed0fe710-586f-41b0-8f13-41c67bbf7828
D, [2023-12-21T15:36:33.478598 #75390] DEBUG -- : [knapsack_pro] API response:
D, [2023-12-21T15:36:33.478612 #75390] DEBUG -- : [knapsack_pro] {"queue_name"=>"130:4165d4447542f8df3d0017898d02c9c8", "build_subset_id"=>nil, "test_files"=>[]}

after suite
D, [2023-12-21T15:36:33.480448 #75390] DEBUG -- : [knapsack_pro] Global time execution for tests: 0.0017349999397993088s
++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
after suite hook called only once
Run this only when using Knapsack Pro Queue Mode
This code is executed outside of the RSpec after(:suite) hook context because it's impossible to determine which after(:suite) is the last one to execute until it's executed.
----------After Queue Hook - run after test suite----------
2nd KnapsackPro::Hooks::Queue.after_queue
I, [2023-12-21T15:36:33.481070 #75390]  INFO -- : [knapsack_pro] To retry all the tests assigned to this CI node, please run the following command on your machine:
I, [2023-12-21T15:36:33.481102 #75390]  INFO -- : [knapsack_pro] bundle exec rspec --format documentation --format RspecJunitFormatter --out tmp/test-reports/rspec/queue_mode/rspec_0.xml --default-path spec
D, [2023-12-21T15:36:33.536835 #75390] DEBUG -- : [knapsack_pro] POST http://api.knapsackpro.test:3000/v1/build_subsets
D, [2023-12-21T15:36:33.536856 #75390] DEBUG -- : [knapsack_pro] API request UUID: 9ded3e64-575b-4a07-a867-4f164d690cc6
D, [2023-12-21T15:36:33.536865 #75390] DEBUG -- : [knapsack_pro] API response:
D, [2023-12-21T15:36:33.536871 #75390] DEBUG -- : [knapsack_pro]
D, [2023-12-21T15:36:33.536882 #75390] DEBUG -- : [knapsack_pro] Saved time execution report on Knapsack Pro API server.
Coverage report generated for RSpec, rspec_ci_node_0, rspec_ci_node_1 to /Users/artur/Documents/github/knapsack-pro/rails-app-with-knapsack_pro/coverage. 325 / 412 LOC (78.88%) covered.
```

## CI node 1

```
➜  rails-app-with-knapsack_pro git:(junit-reports) ✗ bin/knapsack_pro_queue_rspec_record_first_run_junit 1 2 gusto-v9 ci-build-9
D, [2023-12-21T15:36:12.082108 #75392] DEBUG -- : [knapsack_pro] Detected 24 slow test files: [{"path"=>"spec/async/reactor_spec.rb"}, {"path"=>"spec/bar_spec.rb"}, {"path"=>"spec/collection_spec.rb"}, {"path"=>"spec/controllers/articles_controller_spec.rb"}, {"path"=>"spec/controllers/dashboard/pending_controller_spec.rb"}, {"path"=>"spec/controllers/pending_controller_spec.rb"}, {"path"=>"spec/controllers/shared_articles_controller_spec.rb"}, {"path"=>"spec/controllers/welcome_controller_spec.rb"}, {"path"=>"spec/dir with spaces/foobar_spec.rb"}, {"path"=>"spec/features/calculator_spec.rb"}, {"path"=>"spec/features/homepage_spec.rb"}, {"path"=>"spec/foo_spec.rb"}, {"path"=>"spec/options_spec.rb"}, {"path"=>"spec/pending_spec.rb"}, {"path"=>"spec/rake_tasks/dummy_rake_spec.rb"}, {"path"=>"spec/retry_spec.rb"}, {"path"=>"spec/services/calculator_spec.rb"}, {"path"=>"spec/services/meme_spec.rb"}, {"path"=>"spec/slow_shared_examples_spec.rb"}, {"path"=>"spec/system_exit_spec.rb"}, {"path"=>"spec/time_helpers_spec.rb"}, {"path"=>"spec/timecop_spec.rb"}, {"path"=>"spec/track_context_time_spec.rb"}, {"path"=>"spec/vcr_spec.rb"}]
I, [2023-12-21T15:36:12.082290 #75392]  INFO -- : [knapsack_pro] Generating RSpec test examples JSON report for slow test files to prepare it to be split by test examples (by individual test cases). Thanks to that, a single slow test file can be split across parallel CI nodes. Analyzing 24 slow test files.
D, [2023-12-21T15:36:13.642110 #75397] DEBUG -- : [knapsack_pro] Test suite time execution queue recording enabled.
++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
CUSTOM_VARIABLE_FOR_RSPEC_TEST_EXAMPLE_DETECTOR is not set
rspec pid: 75397
Coverage report generated for RSpec, rspec_ci_node_0, rspec_ci_node_1 to /Users/artur/Documents/github/knapsack-pro/rails-app-with-knapsack_pro/coverage. 347 / 412 LOC (84.22%) covered.
I, [2023-12-21T15:36:14.193761 #75392]  INFO -- : [knapsack_pro] Setup RSpec runner.
D, [2023-12-21T15:36:14.246724 #75392] DEBUG -- : [knapsack_pro] Test suite time execution queue recording enabled.
++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
CUSTOM_VARIABLE_FOR_RSPEC_TEST_EXAMPLE_DETECTOR is not set
rspec pid: 75392
++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
RSpec before suite hook called only once
Run this only when using Knapsack Pro Queue Mode
This code is executed within the context of RSpec before(:suite) hook
----------Before Queue Hook - run before test suite----------
2nd KnapsackPro::Hooks::Queue.before_queue
before suite
I, [2023-12-21T15:36:14.696862 #75392]  INFO -- : [knapsack_pro] Fetch test batches from Knapsack Pro API
I, [2023-12-21T15:36:14.696953 #75392]  INFO -- : [knapsack_pro] KNAPSACK_PRO_FIXED_QUEUE_SPLIT is not set. Using default value: true. Learn more at https://knapsackpro.com/perma/ruby/fixed-queue-split
D, [2023-12-21T15:36:14.755478 #75392] DEBUG -- : [knapsack_pro] POST http://api.knapsackpro.test:3000/v1/queues/queue
D, [2023-12-21T15:36:14.755500 #75392] DEBUG -- : [knapsack_pro] API request UUID: b08501e8-bd5f-415c-ab41-745cee7f1cd1
D, [2023-12-21T15:36:14.755510 #75392] DEBUG -- : [knapsack_pro] API response:
D, [2023-12-21T15:36:14.755528 #75392] DEBUG -- : [knapsack_pro] {"queue_name"=>"130:4165d4447542f8df3d0017898d02c9c8", "build_subset_id"=>nil, "test_files"=>[{"path"=>"spec/slow_shared_examples_spec.rb[1:2]", "time_execution"=>11.0350419998867}]}
I, [2023-12-21T15:36:14.755558 #75392]  INFO -- : [knapsack_pro] Wrap tests in before/after subqueue hooks
----------Before Subset Queue Hook - run before the subset of the test suite----------
2nd KnapsackPro::Hooks::Queue.before_subset_queue

Example of slow shared examples
before all
around each start
before each
after each
around each stop
  is expected to equal true
after all
I, [2023-12-21T15:36:25.808804 #75392]  INFO -- : [knapsack_pro] To retry the last batch of tests fetched from the API Queue, please run the following command on your machine:
I, [2023-12-21T15:36:25.808893 #75392]  INFO -- : [knapsack_pro] bundle exec rspec --format documentation --format RspecJunitFormatter --out tmp/test-reports/rspec/queue_mode/rspec_1.xml --default-path spec "spec/slow_shared_examples_spec.rb[1:2]"
----------After Subset Queue Hook - run after the subset of the test suite----------
2nd KnapsackPro::Hooks::Queue.after_subset_queue
D, [2023-12-21T15:36:25.844161 #75392] DEBUG -- : [knapsack_pro] POST http://api.knapsackpro.test:3000/v1/queues/queue
D, [2023-12-21T15:36:25.844192 #75392] DEBUG -- : [knapsack_pro] API request UUID: 26fc7f75-ccad-4a68-a739-ab2fe31d0096
D, [2023-12-21T15:36:25.844202 #75392] DEBUG -- : [knapsack_pro] API response:
D, [2023-12-21T15:36:25.844223 #75392] DEBUG -- : [knapsack_pro] {"queue_name"=>"130:4165d4447542f8df3d0017898d02c9c8", "build_subset_id"=>nil, "test_files"=>[{"path"=>"spec/track_context_time_spec.rb[1:1:2]", "time_execution"=>5.4144980001729}]}
I, [2023-12-21T15:36:25.844246 #75392]  INFO -- : [knapsack_pro] Wrap tests in before/after subqueue hooks
----------Before Subset Queue Hook - run before the subset of the test suite----------
2nd KnapsackPro::Hooks::Queue.before_subset_queue

Track context time
before all
  when something
around each start
before each
after each
around each stop
    test 2
after all
I, [2023-12-21T15:36:31.274766 #75392]  INFO -- : [knapsack_pro] To retry the last batch of tests fetched from the API Queue, please run the following command on your machine:
I, [2023-12-21T15:36:31.274812 #75392]  INFO -- : [knapsack_pro] bundle exec rspec --format documentation --format RspecJunitFormatter --out tmp/test-reports/rspec/queue_mode/rspec_1.xml --default-path spec "spec/track_context_time_spec.rb[1:1:2]"
----------After Subset Queue Hook - run after the subset of the test suite----------
2nd KnapsackPro::Hooks::Queue.after_subset_queue
D, [2023-12-21T15:36:31.300796 #75392] DEBUG -- : [knapsack_pro] POST http://api.knapsackpro.test:3000/v1/queues/queue
D, [2023-12-21T15:36:31.300821 #75392] DEBUG -- : [knapsack_pro] API request UUID: 7051ac8a-b530-4d9b-a72c-3a6f2e985ca8
D, [2023-12-21T15:36:31.300830 #75392] DEBUG -- : [knapsack_pro] API response:
D, [2023-12-21T15:36:31.300848 #75392] DEBUG -- : [knapsack_pro] {"queue_name"=>"130:4165d4447542f8df3d0017898d02c9c8", "build_subset_id"=>nil, "test_files"=>[{"path"=>"spec/timecop_spec.rb[1:1]", "time_execution"=>1.01348900003359}]}
I, [2023-12-21T15:36:31.300865 #75392]  INFO -- : [knapsack_pro] Wrap tests in before/after subqueue hooks
----------Before Subset Queue Hook - run before the subset of the test suite----------
2nd KnapsackPro::Hooks::Queue.before_subset_queue

Timecop
before all
around each start
before each
after each
around each stop
  travel in time
after all
I, [2023-12-21T15:36:32.310562 #75392]  INFO -- : [knapsack_pro] To retry the last batch of tests fetched from the API Queue, please run the following command on your machine:
I, [2023-12-21T15:36:32.310697 #75392]  INFO -- : [knapsack_pro] bundle exec rspec --format documentation --format RspecJunitFormatter --out tmp/test-reports/rspec/queue_mode/rspec_1.xml --default-path spec "spec/timecop_spec.rb[1:1]"
----------After Subset Queue Hook - run after the subset of the test suite----------
2nd KnapsackPro::Hooks::Queue.after_subset_queue
D, [2023-12-21T15:36:32.369019 #75392] DEBUG -- : [knapsack_pro] POST http://api.knapsackpro.test:3000/v1/queues/queue
D, [2023-12-21T15:36:32.369068 #75392] DEBUG -- : [knapsack_pro] API request UUID: aaf76de5-578e-440e-85f6-255df2a0c352
D, [2023-12-21T15:36:32.369085 #75392] DEBUG -- : [knapsack_pro] API response:
D, [2023-12-21T15:36:32.369117 #75392] DEBUG -- : [knapsack_pro] {"queue_name"=>"130:4165d4447542f8df3d0017898d02c9c8", "build_subset_id"=>nil, "test_files"=>[{"path"=>"spec/time_helpers_spec.rb[1:1:1]", "time_execution"=>1.01218500011601}]}
I, [2023-12-21T15:36:32.369163 #75392]  INFO -- : [knapsack_pro] Wrap tests in before/after subqueue hooks
----------Before Subset Queue Hook - run before the subset of the test suite----------
2nd KnapsackPro::Hooks::Queue.before_subset_queue

Time travel with ActiveSupport::Testing::TimeHelpers
before all
  travel_back
around each start
before each
after each
around each stop
    is expected to eq 2004
after all
I, [2023-12-21T15:36:33.376080 #75392]  INFO -- : [knapsack_pro] To retry the last batch of tests fetched from the API Queue, please run the following command on your machine:
I, [2023-12-21T15:36:33.376108 #75392]  INFO -- : [knapsack_pro] bundle exec rspec --format documentation --format RspecJunitFormatter --out tmp/test-reports/rspec/queue_mode/rspec_1.xml --default-path spec "spec/time_helpers_spec.rb[1:1:1]"
----------After Subset Queue Hook - run after the subset of the test suite----------
2nd KnapsackPro::Hooks::Queue.after_subset_queue
D, [2023-12-21T15:36:33.407349 #75392] DEBUG -- : [knapsack_pro] POST http://api.knapsackpro.test:3000/v1/queues/queue
D, [2023-12-21T15:36:33.407369 #75392] DEBUG -- : [knapsack_pro] API request UUID: 23b47a02-6615-4321-a3f8-ef21f964f6e9
D, [2023-12-21T15:36:33.407377 #75392] DEBUG -- : [knapsack_pro] API response:
D, [2023-12-21T15:36:33.407464 #75392] DEBUG -- : [knapsack_pro] {"queue_name"=>"130:4165d4447542f8df3d0017898d02c9c8", "build_subset_id"=>nil, "test_files"=>[{"path"=>"spec/rake_tasks/dummy_rake_spec.rb[1:1:1]", "time_execution"=>0.00181899999734014}, {"path"=>"spec/timecop_spec.rb[1:2]", "time_execution"=>0.0016119999345392}, {"path"=>"spec/bar_spec.rb[1:1]", "time_execution"=>0.00147699995432049}, {"path"=>"spec/retry_spec.rb[1:1]", "time_execution"=>0.000985999940894544}, {"path"=>"spec/dir with spaces/foobar_spec.rb[1:1]", "time_execution"=>0.000817999942228198}, {"path"=>"spec/services/meme_spec.rb[1:1:1]", "time_execution"=>0.000801000045612454}, {"path"=>"spec/collection_spec.rb[4:1:1:1]", "time_execution"=>0.000708000035956502}, {"path"=>"spec/collection_spec.rb[4:1:2:1:1]", "time_execution"=>0.000696999952197075}, {"path"=>"spec/foo_spec.rb[1:1]", "time_execution"=>0.000673000002279878}, {"path"=>"spec/collection_spec.rb[1:1:2:2:1]", "time_execution"=>0.000661999918520451}]}
I, [2023-12-21T15:36:33.407491 #75392]  INFO -- : [knapsack_pro] Wrap tests in before/after subqueue hooks
----------Before Subset Queue Hook - run before the subset of the test suite----------
2nd KnapsackPro::Hooks::Queue.before_subset_queue

Dummy rake
before all
  dummy:do_something_once
around each start
before each
Count: 1
after each
around each stop
    calls the rake task once (increases counter by one)
after all

Bar
before all
around each start
before each
after each
around each stop
  is expected to be a kind of Article(id: integer, title: string, body: text, created_at: datetime, updated_at: datetime)
after all

Retry
before all
around each start
before each
after each
around each stop
around each start
before each
after each
around each stop
  should randomly succeed

1st Try error in ./spec/retry_spec.rb:2:

expected: 1
     got: 0

(compared using ==)


RSpec::Retry: 2nd try ./spec/retry_spec.rb:2
after all

FooBar
before all
around each start
before each
after each
around each stop
  is expected to equal true
after all

Meme
before all
  #i_can_has_cheezburger?
around each start
before each
after each
around each stop
    is expected to eq "OHAI!"
after all

Array
before all
  behaves like a collection
    #include?
      with an an item that is not in the collection
around each start
before each
after each
around each stop
        returns false
after all

MySet
before all
  it should behave like a collection
    initialized with 3 items
around each start
before each
after each
around each stop
      says it has three items
    #include?
      with an an item that is in the collection
around each start
before each
after each
around each stop
        returns true
after all

Foo
before all
around each start
before each
after each
around each stop
  is expected to equal true
after all
I, [2023-12-21T15:36:33.455191 #75392]  INFO -- : [knapsack_pro] To retry the last batch of tests fetched from the API Queue, please run the following command on your machine:
I, [2023-12-21T15:36:33.455222 #75392]  INFO -- : [knapsack_pro] bundle exec rspec --format documentation --format RspecJunitFormatter --out tmp/test-reports/rspec/queue_mode/rspec_1.xml --default-path spec "spec/rake_tasks/dummy_rake_spec.rb[1:1:1]" "spec/timecop_spec.rb[1:2]" "spec/bar_spec.rb[1:1]" "spec/retry_spec.rb[1:1]" "spec/dir with spaces/foobar_spec.rb[1:1]" "spec/services/meme_spec.rb[1:1:1]" "spec/collection_spec.rb[4:1:1:1]" "spec/collection_spec.rb[4:1:2:1:1]" "spec/foo_spec.rb[1:1]" "spec/collection_spec.rb[1:1:2:2:1]"
----------After Subset Queue Hook - run after the subset of the test suite----------
2nd KnapsackPro::Hooks::Queue.after_subset_queue
D, [2023-12-21T15:36:33.476467 #75392] DEBUG -- : [knapsack_pro] POST http://api.knapsackpro.test:3000/v1/queues/queue
D, [2023-12-21T15:36:33.476497 #75392] DEBUG -- : [knapsack_pro] API request UUID: 2557b64a-dfb9-45cc-8c8e-e736742e91bb
D, [2023-12-21T15:36:33.476507 #75392] DEBUG -- : [knapsack_pro] API response:
D, [2023-12-21T15:36:33.476521 #75392] DEBUG -- : [knapsack_pro] {"queue_name"=>"130:4165d4447542f8df3d0017898d02c9c8", "build_subset_id"=>nil, "test_files"=>[]}

after suite
D, [2023-12-21T15:36:33.477899 #75392] DEBUG -- : [knapsack_pro] Global time execution for tests: 0.0012880000285804272s
++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
after suite hook called only once
Run this only when using Knapsack Pro Queue Mode
This code is executed outside of the RSpec after(:suite) hook context because it's impossible to determine which after(:suite) is the last one to execute until it's executed.
----------After Queue Hook - run after test suite----------
2nd KnapsackPro::Hooks::Queue.after_queue
I, [2023-12-21T15:36:33.478600 #75392]  INFO -- : [knapsack_pro] To retry all the tests assigned to this CI node, please run the following command on your machine:
I, [2023-12-21T15:36:33.478618 #75392]  INFO -- : [knapsack_pro] bundle exec rspec --format documentation --format RspecJunitFormatter --out tmp/test-reports/rspec/queue_mode/rspec_1.xml --default-path spec
D, [2023-12-21T15:36:33.512215 #75392] DEBUG -- : [knapsack_pro] POST http://api.knapsackpro.test:3000/v1/build_subsets
D, [2023-12-21T15:36:33.512238 #75392] DEBUG -- : [knapsack_pro] API request UUID: 792a7d94-bf29-4db2-bab8-07cc7d898fdb
D, [2023-12-21T15:36:33.512246 #75392] DEBUG -- : [knapsack_pro] API response:
D, [2023-12-21T15:36:33.512253 #75392] DEBUG -- : [knapsack_pro]
D, [2023-12-21T15:36:33.512264 #75392] DEBUG -- : [knapsack_pro] Saved time execution report on Knapsack Pro API server.
Coverage report generated for RSpec, rspec_ci_node_0, rspec_ci_node_1 to /Users/artur/Documents/github/knapsack-pro/rails-app-with-knapsack_pro/coverage. 309 / 398 LOC (77.64%) covered.
```

## How to reproduce issue:

On CI node 0, you get a batch of tests from Queue API. It includes `spec/controllers/articles_controller_spec.rb[1:1:2]` (1 test case from the `spec/controllers/articles_controller_spec.rb` file. This is the first time we are going to run any test case for that test file on this CI node).

```
[knapsack_pro] API response:
D, [2023-12-21T15:36:33.140425 #75390] DEBUG -- : [knapsack_pro] {"queue_name"=>"130:4165d4447542f8df3d0017898d02c9c8", "build_subset_id"=>nil, "test_files"=>[{"path"=>"spec/features/calculator_spec.rb[1:1:1]", "time_execution"=>0.0201270000543445}, {"path"=>"spec/controllers/articles_controller_spec.rb[1:1:2]", "time_execution"=>0.0173580000409856}]}
```

The next batch gets different test file (`spec/vcr_spec.rb[1:1]`):

```
 API response:
D, [2023-12-21T15:36:33.186326 #75390] DEBUG -- : [knapsack_pro] {"queue_name"=>"130:4165d4447542f8df3d0017898d02c9c8", "build_subset_id"=>nil, "test_files"=>[{"path"=>"spec/vcr_spec.rb[1:1]", "time_execution"=>0.0171789999585599}]}
I, [2023-12-21T15:36:33.186339 #75390]  INFO -- : [knapsack_pro]
```

A few batches later we get another test case from the `spec/controllers/articles_controller_spec.rb` file from Queue API:
The test case is `spec/controllers/articles_controller_spec.rb[1:1:1]`. It's not executed by RSpec. So another batch of tests is fetched from Queue API.

**No more test cases are executed if at least one test case was loaded for a given test file in a previous batch of tests fetched from Queue API.**

```
[knapsack_pro] API response:
D, [2023-12-21T15:36:33.320005 #75390] DEBUG -- : [knapsack_pro] {"queue_name"=>"130:4165d4447542f8df3d0017898d02c9c8", "build_subset_id"=>nil, "test_files"=>[{"path"=>"spec/features/homepage_spec.rb[1:1]", "time_execution"=>0.00712900003418326}, {"path"=>"spec/controllers/articles_controller_spec.rb[1:1:1]", "time_execution"=>0.00480699993204325}]}
I, [2023-12-21T15:36:33.320021 #75390]  INFO -- : [knapsack_pro] Wrap tests in before/after subqueue hooks
----------Before Subset Queue Hook - run before the subset of the test suite----------
2nd KnapsackPro::Hooks::Queue.before_subset_queue
I, [2023-12-21T15:36:33.322684 #75390]  INFO -- : [knapsack_pro] To retry the last batch of tests fetched from the API Queue, please run the following command on your machine:
I, [2023-12-21T15:36:33.322703 #75390]  INFO -- : [knapsack_pro] bundle exec rspec --format documentation --format RspecJunitFormatter --out tmp/test-reports/rspec/queue_mode/rspec_0.xml --default-path spec "spec/features/homepage_spec.rb[1:1]" "spec/controllers/articles_controller_spec.rb[1:1:1]"
----------After Subset Queue Hook - run after the subset of the test suite----------
2nd KnapsackPro::Hooks::Queue.after_subset_queue
```