### PR TITLE
CI: Remove tests that are already covered in Ruby gem

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -69,16 +69,10 @@ jobs:
       - run:
           name: Database setup for parallel_tests gem
           command: TEST_ENV_NUMBER=2 bin/rails db:setup
-      - run:
-          command: |
-            export KNAPSACK_PRO_TEST_SUITE_TOKEN_RSPEC=$KNAPSACK_PRO_QUEUE_TEST_SUITE_TOKEN_RSPEC
-            bundle exec rake knapsack_pro:queue:rspec
 
-      # Queue Mode: retry CI with the same test suite split as the last dynamic queue run.
       # (Test --profile formatter to show only once the profile summary.)
       - run:
           command: |
-            export KNAPSACK_PRO_FIXED_QUEUE_SPLIT=true
             export KNAPSACK_PRO_TEST_SUITE_TOKEN_RSPEC=$KNAPSACK_PRO_QUEUE_TEST_SUITE_TOKEN_RSPEC
             bundle exec rake "knapsack_pro:queue:rspec[--profile]"
 
@@ -112,19 +106,6 @@ jobs:
               echo "Report files not found. Nothing to import to Calliope.pro"
             fi
 
-      # Queue Mode: retry CI with the same test suite split as the last dynamic queue run.
-      - run:
-          command: |
-            export KNAPSACK_PRO_FIXED_QUEUE_SPLIT=true
-            export KNAPSACK_PRO_TEST_SUITE_TOKEN_RSPEC=$KNAPSACK_PRO_QUEUE_TEST_SUITE_TOKEN_RSPEC
-            bundle exec rake knapsack_pro:queue:rspec
-
-      # Queue Mode: connect to a queue of tests that was already all consumed (no tests will run).
-      - run:
-          command: |
-            export KNAPSACK_PRO_TEST_SUITE_TOKEN_RSPEC=$KNAPSACK_PRO_QUEUE_TEST_SUITE_TOKEN_RSPEC
-            bundle exec rake knapsack_pro:queue:rspec
-
       # Queue Mode and parallel_tests gem
       - run:
           command: |
@@ -133,36 +114,6 @@ jobs:
             export KNAPSACK_PRO_CI_NODE_TOTAL=$CIRCLE_NODE_TOTAL
             export KNAPSACK_PRO_CI_NODE_INDEX=$CIRCLE_NODE_INDEX
             bundle exec parallel_test -n $PARALLEL_TESTS_CONCURRENCY -e './bin/parallel_tests'
-
-      # Queue Mode: RSpec split by test examples
-      - run:
-          name: RSpec split by test cases (Queue Mode)
-          command: |
-            export KNAPSACK_PRO_TEST_SUITE_TOKEN_RSPEC=$KNAPSACK_PRO_QUEUE_TEST_SUITE_TOKEN_RSPEC_SPLIT_BY_TEST_CASES
-            export KNAPSACK_PRO_RSPEC_SPLIT_BY_TEST_EXAMPLES=true
-            bundle exec rake knapsack_pro:queue:rspec
-
-      - run:
-          name: RSpec split by test cases (Regular Mode) with KNAPSACK_PRO_SLOW_TEST_FILE_PATTERN
-          command: |
-            export KNAPSACK_PRO_TEST_SUITE_TOKEN_RSPEC=$KNAPSACK_PRO_TEST_SUITE_TOKEN_RSPEC_SPLIT_BY_TEST_CASES
-            export KNAPSACK_PRO_RSPEC_SPLIT_BY_TEST_EXAMPLES=true
-            export KNAPSACK_PRO_SLOW_TEST_FILE_PATTERN="{spec/timecop_spec.rb}"
-            bundle exec rake knapsack_pro:rspec
-
-      # Queue Mode: Minitest
-      - run:
-          command: |
-            export KNAPSACK_PRO_RSPEC_DISABLED=true
-            export KNAPSACK_PRO_TEST_SUITE_TOKEN_MINITEST=$KNAPSACK_PRO_QUEUE_TEST_SUITE_TOKEN_MINITEST
-            bundle exec rake knapsack_pro:queue:minitest[--verbose]
-
-
-      # Regular Mode
-      - run:
-          command: |
-            export KNAPSACK_PRO_FIXED_TEST_SUITE_SPLIT=false
-            bundle exec rake knapsack_pro:rspec
 
       # Regular Mode with junit formatter
       - run:
@@ -248,11 +199,6 @@ jobs:
 
       - run:
           command: |
-            export KNAPSACK_PRO_RSPEC_DISABLED=true
-            bundle exec rake knapsack_pro:minitest[--verbose]
-
-      - run:
-          command: |
             export KNAPSACK_PRO_TEST_DIR=test-unit
             export KNAPSACK_PRO_TEST_FILE_PATTERN="test-unit/**{,/*/**}/*_test.rb"
             bundle exec rake "knapsack_pro:test_unit[--verbose]"
@@ -261,24 +207,6 @@ jobs:
           command: |
             export KNAPSACK_PRO_TEST_FILE_PATTERN="spinach_features/**{,/*/**}/*.feature"
             bundle exec rake knapsack_pro:spinach
-
-      # Check if https endpoint is working
-      - run:
-          command: |
-            export KNAPSACK_PRO_FIXED_TEST_SUITE_SPLIT=false
-            export KNAPSACK_PRO_ENDPOINT=https://api-staging.knapsackpro.com
-            bundle exec rake knapsack_pro:rspec
-
-      - run:
-          command: |
-            export KNAPSACK_PRO_ENDPOINT=https://api-staging.knapsackpro.com
-            bundle exec rake knapsack_pro:cucumber
-
-      - run:
-          command: |
-            export KNAPSACK_PRO_RSPEC_DISABLED=true
-            export KNAPSACK_PRO_ENDPOINT=https://api-staging.knapsackpro.com
-            bundle exec rake knapsack_pro:minitest[--verbose]
 
       # Example of encrypted test files names
       # KNAPSACK_PRO_SALT is set in CircleCI settings
@@ -305,13 +233,6 @@ jobs:
             export KNAPSACK_PRO_BRANCH_ENCRYPTED=true
             export KNAPSACK_PRO_TEST_SUITE_TOKEN_RSPEC=$KNAPSACK_PRO_FOR_ENCRYPTED_QUEUE_TEST_SUITE_TOKEN_RSPEC
             bundle exec rake knapsack_pro:queue:rspec
-
-      # Fallback when cannot connect to API
-      - run:
-          command: |
-            export KNAPSACK_PRO_ENDPOINT=https://api-fake.knapsackpro.com
-            export KNAPSACK_PRO_MAX_REQUEST_RETRIES=1
-            bundle exec rake knapsack_pro:rspec
 
       - run:
           command: |


### PR DESCRIPTION
Remove:
- unneeded tests
- tests that are already covered in https://github.com/KnapsackPro/knapsack_pro-ruby/blob/master/.circleci/config.yml

@ArturT in https://github.com/KnapsackPro/knapsack_pro-ruby/blob/master/.circleci/config.yml we are not using `export KNAPSACK_PRO_RSPEC_DISABLED=true` and it seems https://github.com/KnapsackPro/rails-app-with-knapsack_pro/blob/master/test/minitest/meme_spec_test.rb is run. Could you please double check that we don't need to use the disabled flag?