### PR TITLE
Refactor queue rspec runner

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../knapsack_pro-ruby
   specs:
-    knapsack_pro (6.0.4)
+    knapsack_pro (7.0.0)
       rake
 
 GEM

--- a/bin/edge_cases/knapsack_pro_queue_rspec_record_first_run
+++ b/bin/edge_cases/knapsack_pro_queue_rspec_record_first_run
@@ -41,6 +41,11 @@ KNAPSACK_PRO_ENDPOINT=http://api.knapsackpro.test:3000 \
   KNAPSACK_PRO_CI_NODE_INDEX=${1:-0} \
   bundle exec rake "knapsack_pro:queue:rspec[--format d]"
 
+# do not use the skip tag because it's the internal tag to mark test as pending
+#bundle exec rake "knapsack_pro:queue:rspec[--format d --tag xfocus --tag ~xskip]"
+#bundle exec rake "knapsack_pro:queue:rspec[--format d --tag xfocus]"
+#bundle exec rake "knapsack_pro:queue:rspec[--format d --tag ~xskip]"
+
 echo
 echo
 echo

--- a/bin/edge_cases/knapsack_pro_queue_rspec_record_first_run
+++ b/bin/edge_cases/knapsack_pro_queue_rspec_record_first_run
@@ -47,7 +47,13 @@ KNAPSACK_PRO_ENDPOINT=http://api.knapsackpro.test:3000 \
 #bundle exec rake "knapsack_pro:queue:rspec[--format d --tag ~xskip]"
 #
 #bundle exec rake "knapsack_pro:queue:rspec[--format d --profile]"
-#bundle exec rake "knapsack_pro:queue:rspec[--format d --failure-exit-code]"
+#bundle exec rake "knapsack_pro:queue:rspec[--format d --order random]"
+#
+# --failure-exit-code CODE - Override the exit code used when there are failing specs.
+#bundle exec rake "knapsack_pro:queue:rspec[--format d --failure-exit-code 2]"
+#
+# --error-exit-code CODE - Override the exit code used when there are errors loading or running specs outside of examples.
+#bundle exec rake "knapsack_pro:queue:rspec[--format d --error-exit-code 3]"
 
 #echo
 #echo

--- a/bin/edge_cases/knapsack_pro_queue_rspec_record_first_run
+++ b/bin/edge_cases/knapsack_pro_queue_rspec_record_first_run
@@ -27,6 +27,8 @@ BRANCH_NAME=fake-branch
 #export KNAPSACK_PRO_RSPEC_SPLIT_BY_TEST_EXAMPLES=true
 #export KNAPSACK_PRO_SLOW_TEST_FILE_PATTERN="spec/**{,/*/**}/*_spec.rb"
 
+# In order to mock the Queue API responses, you need to change source code of the knapsack_pro gem:
+# https://github.com/KnapsackPro/rails-app-with-knapsack_pro/pull/56/
 # uncomment all 3 export lines to test mocked API response
 export KNAPSACK_PRO_RSPEC_SPLIT_BY_TEST_EXAMPLES=true
 export KNAPSACK_PRO_SLOW_TEST_FILE_PATTERN="spec/features/calculator_spec.rb" # it must match test cases returned from Queue API
@@ -41,11 +43,9 @@ KNAPSACK_PRO_ENDPOINT=http://api.knapsackpro.test:3000 \
   KNAPSACK_PRO_CI_NODE_INDEX=${1:-0} \
   bundle exec rake "knapsack_pro:queue:rspec[--format d]"
 
-# do not use the skip tag because it's the internal tag to mark test as pending
-#bundle exec rake "knapsack_pro:queue:rspec[--format d --tag xfocus --tag ~xskip]"
-#bundle exec rake "knapsack_pro:queue:rspec[--format d --tag xfocus]"
-#bundle exec rake "knapsack_pro:queue:rspec[--format d --tag ~xskip]"
-#
+# Example options you can pass to RSpec:
+#bundle exec rake "knapsack_pro:queue:rspec[--format d --tag my_tag]"
+#bundle exec rake "knapsack_pro:queue:rspec[--format d --tag my_skip_tag]"
 #bundle exec rake "knapsack_pro:queue:rspec[--format d --profile]"
 #bundle exec rake "knapsack_pro:queue:rspec[--format d --order random]"
 #
@@ -55,12 +55,8 @@ KNAPSACK_PRO_ENDPOINT=http://api.knapsackpro.test:3000 \
 # --error-exit-code CODE - Override the exit code used when there are errors loading or running specs outside of examples.
 #bundle exec rake "knapsack_pro:queue:rspec[--format d --error-exit-code 3]"
 
-#echo
-#echo
-#echo
-#echo
 
-# Run 2nd CI node to ensure the CI build is finished in the user dashboard
+# Uncomment the following to run 2nd CI node to ensure the CI build is finished in the user dashboard
 #KNAPSACK_PRO_ENDPOINT=http://api.knapsackpro.test:3000 \
   #KNAPSACK_PRO_TEST_SUITE_TOKEN_RSPEC=fec3c641a3c4d2e720fe1b6d9dd780bc \
   #KNAPSACK_PRO_CI_NODE_BUILD_ID=$CI_BUILD_ID \

--- a/bin/edge_cases/knapsack_pro_queue_rspec_record_first_run
+++ b/bin/edge_cases/knapsack_pro_queue_rspec_record_first_run
@@ -47,11 +47,12 @@ KNAPSACK_PRO_ENDPOINT=http://api.knapsackpro.test:3000 \
 #bundle exec rake "knapsack_pro:queue:rspec[--format d --tag ~xskip]"
 #
 #bundle exec rake "knapsack_pro:queue:rspec[--format d --profile]"
+#bundle exec rake "knapsack_pro:queue:rspec[--format d --failure-exit-code]"
 
-echo
-echo
-echo
-echo
+#echo
+#echo
+#echo
+#echo
 
 # Run 2nd CI node to ensure the CI build is finished in the user dashboard
 #KNAPSACK_PRO_ENDPOINT=http://api.knapsackpro.test:3000 \

--- a/bin/edge_cases/knapsack_pro_queue_rspec_record_first_run
+++ b/bin/edge_cases/knapsack_pro_queue_rspec_record_first_run
@@ -27,6 +27,11 @@ BRANCH_NAME=fake-branch
 #export KNAPSACK_PRO_RSPEC_SPLIT_BY_TEST_EXAMPLES=true
 #export KNAPSACK_PRO_SLOW_TEST_FILE_PATTERN="spec/**{,/*/**}/*_spec.rb"
 
+# uncomment all 3 export lines to test mocked API response
+export KNAPSACK_PRO_RSPEC_SPLIT_BY_TEST_EXAMPLES=true
+export KNAPSACK_PRO_SLOW_TEST_FILE_PATTERN="spec/features/calculator_spec.rb" # it must match test cases returned from Queue API
+export MOCK_QUEUE_API_RESPONSE=true
+
 KNAPSACK_PRO_ENDPOINT=http://api.knapsackpro.test:3000 \
   KNAPSACK_PRO_TEST_SUITE_TOKEN_RSPEC=fec3c641a3c4d2e720fe1b6d9dd780bc \
   KNAPSACK_PRO_CI_NODE_BUILD_ID=$CI_BUILD_ID \
@@ -42,11 +47,11 @@ echo
 echo
 
 # Run 2nd CI node to ensure the CI build is finished in the user dashboard
-KNAPSACK_PRO_ENDPOINT=http://api.knapsackpro.test:3000 \
-  KNAPSACK_PRO_TEST_SUITE_TOKEN_RSPEC=fec3c641a3c4d2e720fe1b6d9dd780bc \
-  KNAPSACK_PRO_CI_NODE_BUILD_ID=$CI_BUILD_ID \
-  KNAPSACK_PRO_COMMIT_HASH=${3:-$COMMIT_HASH} \
-  KNAPSACK_PRO_BRANCH=$BRANCH_NAME \
-  KNAPSACK_PRO_CI_NODE_TOTAL=${2:-2} \
-  KNAPSACK_PRO_CI_NODE_INDEX=1 \
-  bundle exec rake "knapsack_pro:queue:rspec[--format d]"
+#KNAPSACK_PRO_ENDPOINT=http://api.knapsackpro.test:3000 \
+  #KNAPSACK_PRO_TEST_SUITE_TOKEN_RSPEC=fec3c641a3c4d2e720fe1b6d9dd780bc \
+  #KNAPSACK_PRO_CI_NODE_BUILD_ID=$CI_BUILD_ID \
+  #KNAPSACK_PRO_COMMIT_HASH=${3:-$COMMIT_HASH} \
+  #KNAPSACK_PRO_BRANCH=$BRANCH_NAME \
+  #KNAPSACK_PRO_CI_NODE_TOTAL=${2:-2} \
+  #KNAPSACK_PRO_CI_NODE_INDEX=1 \
+  #bundle exec rake "knapsack_pro:queue:rspec[--format d]"

--- a/bin/edge_cases/knapsack_pro_queue_rspec_record_first_run
+++ b/bin/edge_cases/knapsack_pro_queue_rspec_record_first_run
@@ -45,6 +45,8 @@ KNAPSACK_PRO_ENDPOINT=http://api.knapsackpro.test:3000 \
 #bundle exec rake "knapsack_pro:queue:rspec[--format d --tag xfocus --tag ~xskip]"
 #bundle exec rake "knapsack_pro:queue:rspec[--format d --tag xfocus]"
 #bundle exec rake "knapsack_pro:queue:rspec[--format d --tag ~xskip]"
+#
+#bundle exec rake "knapsack_pro:queue:rspec[--format d --profile]"
 
 echo
 echo

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -31,27 +31,6 @@ require 'simplecov'
 SimpleCov.start
 
 
-before_suite_block = proc {
-  puts '+'*100
-  puts 'RSpec before suite hook called only once'
-}
-
-unless KnapsackPro::Config::Env.queue_recording_enabled?
-  RSpec.configure do |config|
-    config.before(:suite) do
-      before_suite_block.call
-      puts 'Run this only when not using Knapsack Pro Queue Mode'
-    end
-  end
-end
-
-KnapsackPro::Hooks::Queue.before_queue do |queue_id|
-  before_suite_block.call
-  puts 'Run this only when using Knapsack Pro Queue Mode'
-  puts 'This code is executed within the context of RSpec before(:suite) hook'
-end
-
-
 # CUSTOM_CONFIG_GOES_HERE
 KnapsackPro::Hooks::Queue.before_queue do |queue_id|
   print '-'*10

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -80,12 +80,6 @@ KnapsackPro::Hooks::Queue.after_subset_queue do |queue_id, subset_queue_id|
 end
 
 KnapsackPro::Hooks::Queue.after_queue do |queue_id|
-  # Metadata collection
-  # https://circleci.com/docs/1.0/test-metadata/#metadata-collection-in-custom-test-steps
-  if File.exist?(FINAL_RSPEC_XML_REPORT) && ENV['CIRCLE_TEST_REPORTS']
-    FileUtils.cp(FINAL_RSPEC_XML_REPORT, "#{ENV['CIRCLE_TEST_REPORTS']}/rspec.xml")
-  end
-
   print '-'*10
   print 'After Queue Hook - run after test suite'
   print '-'*10

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -52,27 +52,6 @@ KnapsackPro::Hooks::Queue.before_queue do |queue_id|
 end
 
 
-after_suite_block = proc {
-  puts '+'*100
-  puts 'after suite hook called only once'
-}
-
-unless KnapsackPro::Config::Env.queue_recording_enabled?
-  RSpec.configure do |config|
-    config.after(:suite) do
-      after_suite_block.call
-      puts 'Run this only when not using Knapsack Pro Queue Mode'
-    end
-  end
-end
-
-KnapsackPro::Hooks::Queue.after_queue do |queue_id|
-  after_suite_block.call
-  puts 'Run this only when using Knapsack Pro Queue Mode'
-  puts "This code is executed outside of the RSpec after(:suite) hook context because it's impossible to determine which after(:suite) is the last one to execute until it's executed."
-end
-
-
 # CUSTOM_CONFIG_GOES_HERE
 KnapsackPro::Hooks::Queue.before_queue do |queue_id|
   print '-'*10

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -54,22 +54,7 @@ KnapsackPro::Hooks::Queue.before_subset_queue do |queue_id, subset_queue_id|
   puts '2nd KnapsackPro::Hooks::Queue.before_subset_queue'
 end
 
-# TODO This must be the same path as value for rspec --out argument
-TMP_RSPEC_XML_REPORT = "tmp/test-reports/rspec/queue_mode/rspec_#{KnapsackPro::Config::Env.ci_node_index}.xml"
-TMP_RSPEC_JSON_REPORT = "tmp/test-reports/rspec/queue_mode/rspec_#{KnapsackPro::Config::Env.ci_node_index}.json"
-# move results to FINAL_RSPEC_XML_REPORT so the results won't accumulate with duplicated xml tags in TMP_RSPEC_XML_REPORT
-FINAL_RSPEC_XML_REPORT = "tmp/test-reports/rspec/queue_mode/rspec_final_results_#{KnapsackPro::Config::Env.ci_node_index}.xml"
-FINAL_RSPEC_JSON_REPORT = "tmp/test-reports/rspec/queue_mode/rspec_final_results_#{KnapsackPro::Config::Env.ci_node_index}.json"
-
 KnapsackPro::Hooks::Queue.after_subset_queue do |queue_id, subset_queue_id|
-  if File.exist?(TMP_RSPEC_XML_REPORT)
-    FileUtils.mv(TMP_RSPEC_XML_REPORT, FINAL_RSPEC_XML_REPORT)
-  end
-
-  if File.exist?(TMP_RSPEC_JSON_REPORT)
-    FileUtils.mv(TMP_RSPEC_JSON_REPORT, FINAL_RSPEC_JSON_REPORT)
-  end
-
   print '-'*10
   print 'After Subset Queue Hook - run after the subset of the test suite'
   print '-'*10

--- a/spec/support/config/rspec_retry.rb
+++ b/spec/support/config/rspec_retry.rb
@@ -7,7 +7,7 @@ RSpec.configure do |config|
   config.display_try_failure_messages = true
  
   # --fail-fast option makes RSpec fail after X failed tests. This can lead to canceled tests in Queue Mode.
-  #config.fail_fast = 1
+  # config.fail_fast = 1
 
   # run retry only on features
   config.around :each, :js do |ex|

--- a/spec/support/config/rspec_retry.rb
+++ b/spec/support/config/rspec_retry.rb
@@ -5,7 +5,8 @@ RSpec.configure do |config|
   config.verbose_retry = true
   # show exception that triggers a retry if verbose_retry is set to true
   config.display_try_failure_messages = true
-  config.fail_fast = 3
+  # --fail-fast option makes RSpec fail after X failed tests. This can lead to canceled test execution in Queue Mode
+  #config.fail_fast = 1
 
   # run retry only on features
   config.around :each, :js do |ex|


### PR DESCRIPTION
# story
https://trello.com/c/BcBhX2MW

# related

* https://github.com/KnapsackPro/knapsack_pro-ruby/pull/237

# How to mock the Queue API responses in the knapsack_pro gem

You can add the following code to the source code of the Knapsack Pro gem to mock the Queue API responses.
https://github.com/KnapsackPro/knapsack_pro-ruby/pull/237/commits/348f563a1cc5d72ac1684aa3848aa7f749f9a738

```ruby
# lib/knapsack_pro/queue_allocator.rb

    def test_file_paths(can_initialize_queue, executed_test_files)
      if ENV['MOCK_QUEUE_API_RESPONSE'] == 'true'
        @@index ||= 0
        batches = [
          ['spec/features/calculator_spec.rb[1:2:1]', 'spec/controllers/articles_controller_spec.rb'],
          ['spec/collection_spec.rb'],
          ['spec/features/calculator_spec.rb[1:1:1]'],
          ['spec/bar_spec.rb'],
          [], # the last Queue API response is always an empty list of test files
        ]

        # example of an empty batch for a late CI node
        #batches = [
          #[]
        #]
        tests = batches[@@index] || []
        @@index += 1
        puts '='*50
        puts 'Tests (mocked API response):'
        puts tests.inspect
        puts '='*50
        return tests
      end

      return [] if @fallback_activated
...
```