### PR TITLE
Log info about queue batches in RSpec, Minitest, Cucumber in Queue Mode

### DIFF
--- a/features/support/knapsack_pro.rb
+++ b/features/support/knapsack_pro.rb
@@ -8,7 +8,7 @@ KnapsackPro::Hooks::Queue.before_queue do |queue_id|
 
   puts
   puts 'Queue Batches:'
-  puts KnapsackPro::Store::Server.client.queue_batches.inspect
+  puts KnapsackPro::Store::Client.batches.inspect
 end
 
 KnapsackPro::Hooks::Queue.after_subset_queue do |queue_id, subset_queue_id|
@@ -18,7 +18,7 @@ KnapsackPro::Hooks::Queue.after_subset_queue do |queue_id, subset_queue_id|
 
   puts
   puts 'Queue Batches:'
-  puts KnapsackPro::Store::Server.client.queue_batches.inspect
+  puts KnapsackPro::Store::Client.batches.inspect
 end
 
 KnapsackPro::Hooks::Queue.after_queue do |queue_id|
@@ -28,7 +28,7 @@ KnapsackPro::Hooks::Queue.after_queue do |queue_id|
 
   puts
   puts 'Queue Batches:'
-  puts KnapsackPro::Store::Server.client.queue_batches.inspect
+  puts KnapsackPro::Store::Client.batches.inspect
 end
 
 KnapsackPro::Adapters::CucumberAdapter.bind

--- a/features/support/knapsack_pro.rb
+++ b/features/support/knapsack_pro.rb
@@ -3,31 +3,41 @@ require 'knapsack_pro'
 # CUSTOM_CONFIG_GOES_HERE
 KnapsackPro::Hooks::Queue.before_queue do |queue_id|
   print '-'*10
-  print 'Before Queue Hook - run before test suite'
+  print 'Before Queue Hook - run before the test suite'
   print '-'*10
 
   puts
-  puts 'Queue Batches:'
+  print 'Batches in before_queue: '
+  puts KnapsackPro::Store::Client.batches.inspect
+end
+
+KnapsackPro::Hooks::Queue.before_subset_queue do |queue_id, subset_queue_id|
+  print '-'*10
+  print 'Before Subset Queue Hook - run before the next subset of tests'
+  print '-'*10
+
+  puts
+  print 'Batches in before_subset_queue: '
   puts KnapsackPro::Store::Client.batches.inspect
 end
 
 KnapsackPro::Hooks::Queue.after_subset_queue do |queue_id, subset_queue_id|
   print '-'*10
-  print 'After Subset Queue Hook - run after subset of test suite'
+  print 'After Subset Queue Hook - run after the previous subset of tests'
   print '-'*10
 
   puts
-  puts 'Queue Batches:'
+  print 'Batches in after_subset_queue: '
   puts KnapsackPro::Store::Client.batches.inspect
 end
 
 KnapsackPro::Hooks::Queue.after_queue do |queue_id|
   print '-'*10
-  print 'After Queue Hook - run after test suite'
+  print 'After Queue Hook - run after the test suite'
   print '-'*10
 
   puts
-  puts 'Queue Batches:'
+  print 'Batches in after_queue: '
   puts KnapsackPro::Store::Client.batches.inspect
 end
 

--- a/features/support/knapsack_pro.rb
+++ b/features/support/knapsack_pro.rb
@@ -5,18 +5,30 @@ KnapsackPro::Hooks::Queue.before_queue do |queue_id|
   print '-'*10
   print 'Before Queue Hook - run before test suite'
   print '-'*10
+
+  puts
+  puts 'Queue Batches:'
+  puts KnapsackPro::Store::Server.client.queue_batches.inspect
 end
 
 KnapsackPro::Hooks::Queue.after_subset_queue do |queue_id, subset_queue_id|
   print '-'*10
   print 'After Subset Queue Hook - run after subset of test suite'
   print '-'*10
+
+  puts
+  puts 'Queue Batches:'
+  puts KnapsackPro::Store::Server.client.queue_batches.inspect
 end
 
 KnapsackPro::Hooks::Queue.after_queue do |queue_id|
   print '-'*10
   print 'After Queue Hook - run after test suite'
   print '-'*10
+
+  puts
+  puts 'Queue Batches:'
+  puts KnapsackPro::Store::Server.client.queue_batches.inspect
 end
 
 KnapsackPro::Adapters::CucumberAdapter.bind

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -34,7 +34,7 @@ SimpleCov.start
 # CUSTOM_CONFIG_GOES_HERE
 KnapsackPro::Hooks::Queue.before_queue do |queue_id|
   print '-'*10
-  print 'Before Queue Hook - run before test suite'
+  print 'Before Queue Hook - run before the test suite'
   print '-'*10
   puts
 
@@ -46,7 +46,7 @@ end
 
 KnapsackPro::Hooks::Queue.before_subset_queue do |queue_id, subset_queue_id|
   print '-'*10
-  print 'Before Subset Queue Hook - run before the subset of the test suite'
+  print 'Before Subset Queue Hook - run before the next subset of tests'
   print '-'*10
   puts
 end
@@ -56,7 +56,7 @@ end
 
 KnapsackPro::Hooks::Queue.after_subset_queue do |queue_id, subset_queue_id|
   print '-'*10
-  print 'After Subset Queue Hook - run after the subset of the test suite'
+  print 'After Subset Queue Hook - run after the previous subset of tests'
   print '-'*10
   puts
 end
@@ -66,7 +66,7 @@ end
 
 KnapsackPro::Hooks::Queue.after_queue do |queue_id|
   print '-'*10
-  print 'After Queue Hook - run after test suite'
+  print 'After Queue Hook - run after the test suite'
   print '-'*10
   puts
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -36,7 +36,10 @@ KnapsackPro::Hooks::Queue.before_queue do |queue_id|
   print '-'*10
   print 'Before Queue Hook - run before the test suite'
   print '-'*10
+
   puts
+  print 'Batches in before_queue: '
+  puts KnapsackPro::Store::Client.batches.inspect
 
   SimpleCov.command_name("rspec_ci_node_#{KnapsackPro::Config::Env.ci_node_index}")
 end
@@ -48,7 +51,10 @@ KnapsackPro::Hooks::Queue.before_subset_queue do |queue_id, subset_queue_id|
   print '-'*10
   print 'Before Subset Queue Hook - run before the next subset of tests'
   print '-'*10
+
   puts
+  print 'Batches in before_subset_queue: '
+  puts KnapsackPro::Store::Client.batches.inspect
 end
 KnapsackPro::Hooks::Queue.before_subset_queue do |queue_id, subset_queue_id|
   puts '2nd KnapsackPro::Hooks::Queue.before_subset_queue'
@@ -58,7 +64,10 @@ KnapsackPro::Hooks::Queue.after_subset_queue do |queue_id, subset_queue_id|
   print '-'*10
   print 'After Subset Queue Hook - run after the previous subset of tests'
   print '-'*10
+
   puts
+  print 'Batches in after_subset_queue: '
+  puts KnapsackPro::Store::Client.batches.inspect
 end
 KnapsackPro::Hooks::Queue.after_subset_queue do |queue_id, subset_queue_id|
   puts '2nd KnapsackPro::Hooks::Queue.after_subset_queue'
@@ -68,7 +77,10 @@ KnapsackPro::Hooks::Queue.after_queue do |queue_id|
   print '-'*10
   print 'After Queue Hook - run after the test suite'
   print '-'*10
+
   puts
+  print 'Batches in after_queue: '
+  puts KnapsackPro::Store::Client.batches.inspect
 end
 KnapsackPro::Hooks::Queue.after_queue do |queue_id|
   puts '2nd KnapsackPro::Hooks::Queue.after_queue'

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -8,20 +8,42 @@ require 'knapsack_pro'
 # CUSTOM_CONFIG_GOES_HERE
 KnapsackPro::Hooks::Queue.before_queue do |queue_id|
   print '-'*10
-  print 'Before Queue Hook - run before test suite'
+  print 'Before Queue Hook - run before the test suite'
   print '-'*10
+
+  puts
+  print 'Batches in before_queue: '
+  puts KnapsackPro::Store::Client.batches.inspect
+end
+
+KnapsackPro::Hooks::Queue.before_subset_queue do |queue_id, subset_queue_id|
+  print '-'*10
+  print 'Before Subset Queue Hook - run before the next subset of tests'
+  print '-'*10
+
+  puts
+  print 'Batches in before_subset_queue: '
+  puts KnapsackPro::Store::Client.batches.inspect
 end
 
 KnapsackPro::Hooks::Queue.after_subset_queue do |queue_id, subset_queue_id|
   print '-'*10
-  print 'After Subset Queue Hook - run after subset of test suite'
+  print 'After Subset Queue Hook - run after the previous subset of tests'
   print '-'*10
+
+  puts
+  print 'Batches in after_subset_queue: '
+  puts KnapsackPro::Store::Client.batches.inspect
 end
 
 KnapsackPro::Hooks::Queue.after_queue do |queue_id|
   print '-'*10
-  print 'After Queue Hook - run after test suite'
+  print 'After Queue Hook - run after the test suite'
   print '-'*10
+
+  puts
+  print 'Batches in after_queue: '
+  puts KnapsackPro::Store::Client.batches.inspect
 end
 
 knapsack_pro_adapter = KnapsackPro::Adapters::MinitestAdapter.bind


### PR DESCRIPTION
Log info about queue batches in RSpec, Minitest, Cucumber in Queue Mode to ensure using public class interface (`KnapsackPro::Store::Client.batches`) from the gem works.

# related

* https://github.com/KnapsackPro/knapsack_pro-ruby/pull/252