### PR TITLE
Update simplecov from 0.17.1 to 0.22.0 and update config for Minitest + Queue Mode + simplecov

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -272,7 +272,7 @@ jobs:
       - run:
           name: Code Climate Test Coverage
           command: |
-            ./cc-test-reporter format-coverage -t simplecov -o "coverage/codeclimate.$CIRCLE_NODE_INDEX.json"
+            ./cc-test-reporter format-coverage -t simplecov -o "coverage/codeclimate.$CIRCLE_NODE_INDEX.json" --debug
       - persist_to_workspace:
           root: coverage
           paths:

--- a/Gemfile
+++ b/Gemfile
@@ -100,9 +100,7 @@ group :test do
   #gem 'capybara-screenshot', github: 'ArturT/capybara-screenshot', branch: 'fix-reporter_module-loaded-twice'
 
   gem 'shared_should', require: false
-  # use older simplecov to fix an issue with CodeClimate
-  # https://github.com/codeclimate/test-reporter/issues/418
-  gem 'simplecov', '0.17.1', require: false
+  gem 'simplecov', require: false
 end
 
 gem "turnip", "~> 4.4"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -316,11 +316,12 @@ GEM
     shoulda-context (2.0.0)
     shoulda-matchers (4.5.1)
       activesupport (>= 4.2.0)
-    simplecov (0.17.1)
+    simplecov (0.22.0)
       docile (~> 1.1)
-      json (>= 1.8, < 3)
-      simplecov-html (~> 0.10.0)
-    simplecov-html (0.10.2)
+      simplecov-html (~> 0.11)
+      simplecov_json_formatter (~> 0.1)
+    simplecov-html (0.12.3)
+    simplecov_json_formatter (0.1.4)
     spinach (0.12.0)
       colorize
       gherkin-ruby (>= 0.3.2)
@@ -422,7 +423,7 @@ DEPENDENCIES
   rspec_junit_formatter
   sass-rails (~> 5.0)
   shared_should
-  simplecov (= 0.17.1)
+  simplecov
   spinach
   spring
   spring-commands-cucumber

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -28,6 +28,12 @@ require 'knapsack_pro'
 #KnapsackPro.logger.level = Logger::INFO
 
 require 'simplecov'
+
+if ENV['CI']
+  require 'simplecov_json_formatter'
+  SimpleCov.formatter = SimpleCov::Formatter::JSONFormatter
+end
+
 SimpleCov.start
 
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -34,6 +34,12 @@ knapsack_pro_adapter = KnapsackPro::Adapters::MinitestAdapter.bind
 knapsack_pro_adapter.set_test_helper_path(__FILE__)
 
 require 'simplecov'
+
+if ENV['CI']
+  require 'simplecov_json_formatter'
+  SimpleCov.formatter = SimpleCov::Formatter::JSONFormatter
+end
+
 SimpleCov.start
 
 KnapsackPro::Hooks::Queue.before_queue do |queue_id|

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -40,6 +40,10 @@ KnapsackPro::Hooks::Queue.before_queue do |queue_id|
   SimpleCov.command_name("minitest_ci_node_#{KnapsackPro::Config::Env.ci_node_index}")
 end
 
+KnapsackPro::Hooks::Queue.after_queue do
+  SimpleCov.result.format!
+end
+
 class ActiveSupport::TestCase
   # Setup all fixtures in test/fixtures/*.yml for all tests in alphabetical order.
   fixtures :all


### PR DESCRIPTION
* Update simplecov from 0.17.1 to 0.22.0 and update config for Minitest + Queue Mode + simplecov
* After updating simplecov, CodeClimate integration fails due to:

```
Error: json: cannot unmarshal object into Go struct field resultSet.coverage of type []formatters.NullInt
```

This PR fixes it as suggested here:

* https://github.com/codeclimate/test-reporter/issues/418#issuecomment-1688052078

Related: 
* https://github.com/KnapsackPro/knapsack_pro-ruby/issues/257