### PR TITLE
debug: reproduce an error `test_#index is already defined` in Minitest in Queue Mode

### DIFF
--- a/bin/knapsack_pro_queue_minitest
+++ b/bin/knapsack_pro_queue_minitest
@@ -2,6 +2,9 @@
 
 CI_BUILD_ID=$(openssl rand -base64 32)
 
+export MOCK_QUEUE_API_RESPONSE=true
+export KNAPSACK_PRO_LOG_LEVEL=debug
+
 # you can test running only minitest spec file to see if spec syntax works for minitest
 #KNAPSACK_PRO_TEST_FILE_LIST=test/minitest/meme_spec_test.rb \
 KNAPSACK_PRO_RSPEC_DISABLED=true \

--- a/test/1_test.rb
+++ b/test/1_test.rb
@@ -1,0 +1,16 @@
+require 'test_helper'
+
+class WelcomeControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    # blah
+  end
+
+  test '#index' do
+    # test goes here
+  end
+
+  # if I uncomment the 2nd test case within the same class (WelcomeControllerTest) then it would fail
+  #test '#index' do
+    ## test goes here
+  #end
+end

--- a/test/2_test.rb
+++ b/test/2_test.rb
@@ -1,0 +1,11 @@
+require 'test_helper'
+
+class ArticlesControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    # blah
+  end
+
+  test '#index' do
+    # test goes here
+  end
+end


### PR DESCRIPTION
Debug Minitest and Queue Mode, to reproduce the following error:

```
rake aborted!
test_#index is already defined in WelcomeControllerTest
```

# Related change in the knaspack_pro gem to mock API response

* https://github.com/KnapsackPro/knapsack_pro-ruby/pull/259