### PR TITLE
Reproduce issue when Timecop mocks the Process.clock_gettime

### DIFF
--- a/spec/support/config/timecop.rb
+++ b/spec/support/config/timecop.rb
@@ -1,0 +1,3 @@
+# https://github.com/travisjeffery/timecop
+
+Timecop.mock_process_clock = true

--- a/spec/timecop_spec.rb
+++ b/spec/timecop_spec.rb
@@ -2,6 +2,13 @@ describe 'Timecop' do
   let(:time_1) { Time.local(2015, 12, 1) }
   let(:time_2) { Time.local(2016, 1, 21) }
 
+  before do
+    Timecop.travel(time_1)
+  end
+  after do
+    #Timecop.return
+  end
+
   it 'travel in time' do
     sleep 1
     Timecop.travel(time_1)


### PR DESCRIPTION
# story

[Internal story.](https://trello.com/c/EVsS01sV)

# How to reproduce the issue

Run:

```
bin/edge_cases/knapsack_pro_queue_rspec_in_background 2024-06-18-v11
```

in the https://github.com/KnapsackPro/rails-app-with-knapsack_pro

to see an error `spec/timecop_spec.rb[1:2] time execution must be greater or equal to 0` in the response from API:

```
E, [2015-12-01T00:00:00.155289 #15879] ERROR -- : [knapsack_pro] {"errors"=>[{"test_files"=>[{"1"=>{"time_execution"=>["spec/timecop_spec.rb[1:2] time execution must be greater or equal to 0"]}}]}]}
rake aborted!
ArgumentError: {"errors"=>[{"test_files"=>[{"1"=>{"time_execution"=>["spec/timecop_spec.rb[1:2] time execution must be greater or equal to 0"]}}]}]} (ArgumentError)

        raise ArgumentError.new(response) if connection.errors?
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^
/Users/artur/Documents/github/knapsack-pro/knapsack_pro-ruby/lib/knapsack_pro/report.rb:78:in `create_build_subset'
/Users/artur/Documents/github/knapsack-pro/knapsack_pro-ruby/lib/knapsack_pro/report.rb:60:in `save_node_queue_to_api'
/Users/artur/Documents/github/knapsack-pro/knapsack_pro-ruby/lib/knapsack_pro/runners/queue/rspec_runner.rb:139:in `post_run_tasks'
```

# related

Fix in the knapsack_pro gem:

* https://github.com/KnapsackPro/knapsack_pro-ruby/pull/262

