### PR TITLE
Create time_tracker_spec.rb to reproduce an error

### DIFF
--- a/spec/time_tracker_spec.rb
+++ b/spec/time_tracker_spec.rb
@@ -2,7 +2,7 @@
 # https://github.com/KnapsackPro/knapsack_pro-ruby/pull/265
 require 'spec_helper'
 
-describe 'Test Time Tracker' do
+describe "Verify KnapsackPro::Formatters::TimeTracker works for Regular Mode in the knapsack_pro gem when the .rspec file does not exist (it does not load spec_helper by default at RSpec start), but spec_helper is loaded later after this spec is loaded (note there is require 'spec_helper' at the top). This spec must be run as part of the CI pipeline in the knapsack_pro gem" do
   it do
     expect(true).to be true
   end

--- a/spec/time_tracker_spec.rb
+++ b/spec/time_tracker_spec.rb
@@ -1,0 +1,9 @@
+# Needed to reproduce the issue:
+# https://github.com/KnapsackPro/knapsack_pro-ruby/pull/265
+require 'spec_helper'
+
+describe 'Test Time Tracker' do
+  it do
+    expect(true).to be true
+  end
+end


### PR DESCRIPTION
add a spec file that explicitly requires spec_helper

# related

* https://github.com/KnapsackPro/knapsack_pro-ruby/pull/265